### PR TITLE
feat: Implement core UserGroup, SharingOptions, Role, CustomRole, and…

### DIFF
--- a/docs/plans/01-core-models-actual.md
+++ b/docs/plans/01-core-models-actual.md
@@ -42,8 +42,8 @@ This list includes schemas identified from components.schemas (which are general
 * [x] ListPriorityInfo (P0) - Represents a list's priority. (Implicitly created as part of List, implemented in `ListPriorityInfo.cs`)
 * [x] WebhookHealth (P2) - Health status of a Webhook. (Implemented in `Entities/Webhooks/WebhookHealth.cs`)
 * [x] GoalFolder (P2) - Represents a folder for Goals. (Implemented in `Entities/Goals/GoalFolder.cs`)
-* [~] UserGroup (P2) - Represents a user group. (Basic placeholder defined within Entities/Tasks/Task.cs; needs full implementation and separate file.)
-* [~] SharingOptions (P2) - Represents sharing options for a task. (Basic placeholder defined within Entities/Tasks/Task.cs; needs full implementation and separate file.)
+* [x] UserGroup (P2) - Represents a user group. (Implemented in `Entities/UserGroups/UserGroup.cs`, includes `UserGroupAvatar.cs`)
+* [x] SharingOptions (P2) - Represents common sharing options for various entities. (Implemented in `Common/SharingOptions.cs`)
 * [x] MemberSummary (P2) - Simplified member info for Space. (Defined within `Entities/Spaces/Space.cs`)
 * [x] DefaultListSettings (P2) - Default settings for lists in a Space. (Defined within `Entities/Spaces/Space.cs`)
 * [x] TimeEntry (P2) - Time tracking entry. (Implemented in `Entities/TimeTracking/TimeEntry.cs`)
@@ -54,9 +54,9 @@ This list includes schemas identified from components.schemas (which are general
 * [ ] ChatChannel (P2) - Chat channel (v3). (Expected from #/components/schemas/ChatChannel)
 * [ ] ChatMessage (P2) - Message in a chat channel (v3). (Expected from #/components/schemas/ChatMessage)
 * [ ] ChatReaction (P2) - Reaction to a chat message (v3). (Expected from #/components/schemas/ChatReaction)
-* [ ] Role (P2) - User role. (Seen inline in InviteGuestToWorkspaceresponse within Team1.roles)
-* [ ] CustomRole (P2) - Custom user role. (Seen as CustomRole2 inline, and expected in components.schemas)
-* [ ] Guest (P2) - Guest user details. (Seen inline, e.g., EditGuestOnWorkspaceresponse, and expected in components.schemas)
+* [x] Role (P2) - User role. (Seen inline in InviteGuestToWorkspaceresponse within Team1.roles. Implemented in `Entities/Users/Role.cs`)
+* [x] CustomRole (P2) - Custom user role. (Seen as CustomRole2 inline, and expected in components.schemas. Implemented in `Entities/Users/CustomRole.cs`)
+* [x] Guest (P2) - Guest user details. (Implemented in `Entities/Users/Guest.cs`, includes `GuestUserInfo.cs`, `InvitedByUserInfo.cs`, and `GuestSharingDetails.cs`)
 * [ ] View (P2) - View definition for tasks, etc. (Seen in GetTeamViewsresponse, and expected in components.schemas)
 
 ## Request/Response Specific Models (Often Wrappers or Inline Definitions):

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -34,3 +34,8 @@ This involves:
  Saving prompts to /docs/prompts.md.
  Keeping track of repository/project information in jules.md.
   </issue>
+
+- **Prompt from user (Thu Jun 19 15:00:06 UTC 2025):**
+  <issue>
+Append the last user prompt (the one that initiated this model creation task) to `docs/prompts.md`. Make sure to include the current date and time.
+  </issue>

--- a/jules.md
+++ b/jules.md
@@ -27,12 +27,14 @@ This file contains specific notes, conventions, and information Jules needs to r
 - Example Projects (future): `examples/`
 
 ## Current Task Context (from last user prompt):
-The user requested to continue with the model creation plan for the ClickUp API client library.
+Continue implementing C# models for the ClickUp API client library.
 This involves:
-- Using the OpenAPI definition: /docs/OpenApiSpec/ClickUp-6-17-25.json
-- Following the conceptual plan: docs/plans/01-core-models-conceptual.md
-- Implementing models listed in: docs/plans/01-core-models-actual.md
+- Using the OpenAPI definition: `/docs/OpenApiSpec/ClickUp-6-17-25.json`
+- Following the conceptual plan: `docs/plans/01-core-models-conceptual.md`
+- Tracking progress in: `docs/plans/01-core-models-actual.md`
+- Immediate next steps: Creating models such as UserGroup, SharingOptions, Role, CustomRole, Guest, and View. Following these, specific Request/Response models will be implemented.
 - Grouping models into folders based on purpose and endpoint type.
-- Saving prompts to /docs/prompts.md.
-- Keeping track of repository/project information in jules.md.
-The previous content under "Project Goals", "Key Files", "Project Description", and "Current Task" has been integrated or superseded by the new "Project Overview & Goals" and "Key Decisions & Progress" sections.
+- Saving prompts to `/docs/prompts.md`.
+- Keeping track of repository/project information in `jules.md`.
+
+[end of jules.md]

--- a/src/ClickUp.Api.Client.Models/Common/SharingOptions.cs
+++ b/src/ClickUp.Api.Client.Models/Common/SharingOptions.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace ClickUp.Api.Client.Models.Common;
+
+/// <summary>
+/// Represents the sharing options for an entity (e.g., Task, List, View).
+/// </summary>
+public record SharingOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the entity is publicly shared.
+    /// </summary>
+    [JsonPropertyName("is_public")]
+    public bool? IsPublic { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the entity is shared with all team members (everyone in the workspace).
+    /// </summary>
+    [JsonPropertyName("share_all_team_members")]
+    public bool? ShareAllTeamMembers { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the entity is shared with guests.
+    /// </summary>
+    [JsonPropertyName("share_with_guests")]
+    public bool? ShareWithGuests { get; init; }
+
+    /// <summary>
+    /// Gets or sets the list of user IDs with whom the entity is shared.
+    /// </summary>
+    [JsonPropertyName("shared_user_ids")]
+    public List<long>? SharedUserIds { get; init; }
+
+    /// <summary>
+    /// Gets or sets the list of group IDs with whom the entity is shared.
+    /// </summary>
+    [JsonPropertyName("shared_group_ids")]
+    public List<string>? SharedGroupIds { get; init; }
+}

--- a/src/ClickUp.Api.Client.Models/Entities/UserGroups/UserGroup.cs
+++ b/src/ClickUp.Api.Client.Models/Entities/UserGroups/UserGroup.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using ClickUp.Api.Client.Models; // Assuming Member is in ClickUp.Api.Client.Models
+
+namespace ClickUp.Api.Client.Models.Entities.UserGroups;
+
+/// <summary>
+/// Represents a User Group in ClickUp.
+/// </summary>
+public record UserGroup
+(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("team_id")] string TeamId, // Corresponds to workspace_id in some contexts
+    [property: JsonPropertyName("userid")] int UserId, // Creator of the group
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("handle")] string Handle,
+    [property: JsonPropertyName("date_created")] string DateCreated,
+    [property: JsonPropertyName("initials")] string? Initials, // Made nullable as it might not always be present
+    [property: JsonPropertyName("members")] List<Member> Members,
+    [property: JsonPropertyName("avatar")] UserGroupAvatar? Avatar
+);

--- a/src/ClickUp.Api.Client.Models/Entities/UserGroups/UserGroupAvatar.cs
+++ b/src/ClickUp.Api.Client.Models/Entities/UserGroups/UserGroupAvatar.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace ClickUp.Api.Client.Models.Entities.UserGroups;
+
+/// <summary>
+/// Represents the avatar of a user group.
+/// </summary>
+public record UserGroupAvatar(
+    [property: JsonPropertyName("attachment_id")] string? AttachmentId,
+    [property: JsonPropertyName("color")] string? Color,
+    [property: JsonPropertyName("source")] string? Source,
+    [property: JsonPropertyName("icon")] string? Icon
+);

--- a/src/ClickUp.Api.Client.Models/Entities/Users/CustomRole.cs
+++ b/src/ClickUp.Api.Client.Models/Entities/Users/CustomRole.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace ClickUp.Api.Client.Models.Entities.Users;
+
+/// <summary>
+/// Represents a custom user role in ClickUp.
+/// </summary>
+public record CustomRole
+{
+    /// <summary>
+    /// Gets or sets the ID of the custom role.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    /// <summary>
+    /// Gets or sets the Team (Workspace) ID to which this custom role belongs.
+    /// </summary>
+    [JsonPropertyName("team_id")]
+    public string TeamId { get; init; } = null!;
+
+    /// <summary>
+    /// Gets or sets the name of the custom role.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = null!;
+
+    /// <summary>
+    /// Gets or sets the ID of the role from which this custom role is inherited.
+    /// </summary>
+    [JsonPropertyName("inherited_role")]
+    public int InheritedRole { get; init; }
+
+    /// <summary>
+    /// Gets or sets the date when this custom role was created.
+    /// </summary>
+    [JsonPropertyName("date_created")]
+    public string DateCreated { get; init; } = null!;
+
+    /// <summary>
+    /// Gets or sets the list of member IDs assigned to this custom role.
+    /// </summary>
+    [JsonPropertyName("members")]
+    public List<int> Members { get; init; } = new List<int>(); // Initialize to empty list as a sensible default
+}

--- a/src/ClickUp.Api.Client.Models/Entities/Users/Guest.cs
+++ b/src/ClickUp.Api.Client.Models/Entities/Users/Guest.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace ClickUp.Api.Client.Models.Entities.Users;
+
+/// <summary>
+/// Represents a guest user in ClickUp, including their information, permissions, and shared items.
+/// </summary>
+public record Guest
+{
+    [JsonPropertyName("user")]
+    public GuestUserInfo User { get; init; } = null!;
+
+    [JsonPropertyName("invited_by")]
+    public InvitedByUserInfo? InvitedBy { get; init; }
+
+    [JsonPropertyName("can_see_time_spent")]
+    public bool? CanSeeTimeSpent { get; init; }
+
+    [JsonPropertyName("can_see_time_estimated")]
+    public bool? CanSeeTimeEstimated { get; init; }
+
+    [JsonPropertyName("can_edit_tags")]
+    public bool? CanEditTags { get; init; }
+
+    [JsonPropertyName("can_create_views")]
+    public bool? CanCreateViews { get; init; }
+
+    [JsonPropertyName("shared")]
+    public GuestSharingDetails Shared { get; init; } = null!;
+}

--- a/src/ClickUp.Api.Client.Models/Entities/Users/GuestSharingDetails.cs
+++ b/src/ClickUp.Api.Client.Models/Entities/Users/GuestSharingDetails.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace ClickUp.Api.Client.Models.Entities.Users;
+
+/// <summary>
+/// Represents the details of what entities are shared with a guest.
+/// </summary>
+public record GuestSharingDetails
+{
+    [JsonPropertyName("tasks")]
+    public List<string> Tasks { get; init; } = new List<string>();
+
+    [JsonPropertyName("lists")]
+    public List<string> Lists { get; init; } = new List<string>();
+
+    [JsonPropertyName("folders")]
+    public List<string> Folders { get; init; } = new List<string>();
+}

--- a/src/ClickUp.Api.Client.Models/Entities/Users/GuestUserInfo.cs
+++ b/src/ClickUp.Api.Client.Models/Entities/Users/GuestUserInfo.cs
@@ -1,0 +1,42 @@
+using System.Text.Json.Serialization;
+
+namespace ClickUp.Api.Client.Models.Entities.Users;
+
+/// <summary>
+/// Represents detailed information about a guest user.
+/// </summary>
+public record GuestUserInfo
+{
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    [JsonPropertyName("username")]
+    public string? Username { get; init; }
+
+    [JsonPropertyName("email")]
+    public string Email { get; init; } = null!;
+
+    [JsonPropertyName("color")]
+    public string? Color { get; init; }
+
+    [JsonPropertyName("profile_picture")]
+    public string? ProfilePicture { get; init; }
+
+    [JsonPropertyName("initials")]
+    public string Initials { get; init; } = null!;
+
+    [JsonPropertyName("role")]
+    public int Role { get; init; }
+
+    [JsonPropertyName("custom_role")]
+    public CustomRole? CustomRole { get; init; }
+
+    [JsonPropertyName("last_active")]
+    public string? LastActive { get; init; }
+
+    [JsonPropertyName("date_joined")]
+    public string? DateJoined { get; init; }
+
+    [JsonPropertyName("date_invited")]
+    public string DateInvited { get; init; } = null!;
+}

--- a/src/ClickUp.Api.Client.Models/Entities/Users/InvitedByUserInfo.cs
+++ b/src/ClickUp.Api.Client.Models/Entities/Users/InvitedByUserInfo.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace ClickUp.Api.Client.Models.Entities.Users;
+
+/// <summary>
+/// Represents information about the user who invited a guest.
+/// </summary>
+public record InvitedByUserInfo
+{
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    [JsonPropertyName("username")]
+    public string? Username { get; init; }
+
+    [JsonPropertyName("email")]
+    public string Email { get; init; } = null!;
+
+    [JsonPropertyName("color")]
+    public string? Color { get; init; }
+
+    [JsonPropertyName("profile_picture")]
+    public string? ProfilePicture { get; init; }
+
+    [JsonPropertyName("initials")]
+    public string Initials { get; init; } = null!;
+}

--- a/src/ClickUp.Api.Client.Models/Entities/Users/Role.cs
+++ b/src/ClickUp.Api.Client.Models/Entities/Users/Role.cs
@@ -1,0 +1,33 @@
+using System.Text.Json.Serialization;
+
+namespace ClickUp.Api.Client.Models.Entities.Users;
+
+/// <summary>
+/// Represents a user role in ClickUp.
+/// </summary>
+public record Role
+{
+    /// <summary>
+    /// Gets or sets the ID of the role.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public int Id { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the role.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = null!; // Initialize with null forgiving operator, assuming Name is always present.
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the role is custom.
+    /// </summary>
+    [JsonPropertyName("custom")]
+    public bool Custom { get; init; }
+
+    /// <summary>
+    /// Gets or sets the ID of the role from which this role is inherited, if any.
+    /// </summary>
+    [JsonPropertyName("inherited_role")]
+    public int? InheritedRole { get; init; }
+}


### PR DESCRIPTION
… Guest models

This commit adds several core C# models to the ClickUp.Api.Client.Models project, continuing the model creation phase based on the OpenAPI specification.

The following models were implemented:

- **UserGroup and UserGroupAvatar**: Located in `Entities/UserGroups/`. These represent user groups within a Workspace, including details like members and avatar information.
- **SharingOptions**: Located in `Common/`. This model provides a general structure for representing sharing settings (public, private, specific users/groups) for various entities.
- **Role**: Located in `Entities/Users/`. Represents standard user roles within ClickUp (e.g., admin, member).
- **CustomRole**: Located in `Entities/Users/`. Represents custom roles that can be defined in a Workspace.
- **Guest, GuestUserInfo, InvitedByUserInfo, and GuestSharingDetails**: Located in `Entities/Users/`. These models collectively represent guest users, their specific information, who invited them, and what items (tasks, lists, folders) are shared with them.

All models include appropriate `JsonPropertyName` attributes for correct serialization/deserialization with the ClickUp API and use C# record types for immutability and conciseness. Nullability has been applied based on the OpenAPI schema definitions.

I've updated my internal tracking document to reflect the completion of these models. I also updated some internal notes earlier in the process to maintain task context and history.