### PR TITLE
I've been working to fix the service implementation errors.

### DIFF
--- a/build_and_capture_output.sh
+++ b/build_and_capture_output.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Perform the build and capture detailed error output
+
+# Add .dotnet tools to PATH
+export PATH="/home/jules/.dotnet:/home/jules/.dotnet/tools:$PATH"
+
+echo "Attempting to build the solution and capture error details..."
+SOLUTION_FILE="src/ClickUp.Api.sln"
+
+if [ -f "$SOLUTION_FILE" ]; then
+  # Capture the full output of the build command
+  BUILD_OUTPUT=$(dotnet build "$SOLUTION_FILE" --nologo)
+  BUILD_STATUS=$? # Capture the exit status of the build command
+
+  if [ $BUILD_STATUS -eq 0 ]; then
+    echo "Build completed successfully."
+    echo "$BUILD_OUTPUT" # Print the output anyway, though it might be minimal for success
+  else
+    echo "Build failed with status $BUILD_STATUS."
+    echo "---------------- BUILD OUTPUT START ----------------"
+    echo "$BUILD_OUTPUT"
+    echo "---------------- BUILD OUTPUT END ------------------"
+  fi
+  # It's important that this script exits with the build status
+  # so the calling agent knows if the build succeeded or failed.
+  exit $BUILD_STATUS
+else
+  echo "Error: Solution file '$SOLUTION_FILE' not found."
+  exit 1
+fi

--- a/build_solution.sh
+++ b/build_solution.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Perform initial build
+
+# Add .dotnet tools to PATH
+export PATH="/home/jules/.dotnet:/home/jules/.dotnet/tools:$PATH"
+
+echo "Attempting to build the solution..."
+# Using a variable to store the path to the solution file for clarity
+SOLUTION_FILE="src/ClickUp.Api.sln"
+
+if [ -f "$SOLUTION_FILE" ]; then
+  dotnet build "$SOLUTION_FILE" --nologo
+  BUILD_STATUS=$?
+  if [ $BUILD_STATUS -eq 0 ]; then
+    echo "Build completed successfully."
+  else
+    echo "Build failed with status $BUILD_STATUS. Errors are listed above."
+  fi
+  exit $BUILD_STATUS
+else
+  echo "Error: Solution file '$SOLUTION_FILE' not found."
+  exit 1
+fi

--- a/install_dotnet.sh
+++ b/install_dotnet.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Install .NET SDK
+chmod +x utilities/dotnet-install.sh
+echo "Attempting to install .NET SDK 9.0..."
+./utilities/dotnet-install.sh --channel 9.0
+INSTALL_STATUS=$?
+if [ $INSTALL_STATUS -eq 0 ]; then
+  echo ".NET SDK installation script completed successfully."
+  # Attempt to add dotnet to PATH for the current session
+  # The script typically suggests a path like /root/.dotnet or /home/user/.dotnet
+  # We'll try to find it and add it.
+  DOTNET_ROOT=$(find ~ -maxdepth 1 -type d -name ".dotnet" -print -quit)
+  if [ -n "$DOTNET_ROOT" ] && [ -d "$DOTNET_ROOT" ]; then
+    export PATH="$DOTNET_ROOT:$DOTNET_ROOT/tools:$PATH"
+    echo "Attempted to add $DOTNET_ROOT to PATH."
+    dotnet --version
+    PROBE_STATUS=$?
+    if [ $PROBE_STATUS -eq 0 ]; then
+      echo "dotnet command found and working."
+    else
+      echo "dotnet command still not found after attempting to set PATH. Further PATH adjustments might be needed or the script might have installed it elsewhere."
+    fi
+  else
+    echo ".dotnet directory not found in home. dotnet might be installed elsewhere or not at all."
+  fi
+else
+  echo ".NET SDK installation script failed with status $INSTALL_STATUS."
+fi
+exit $INSTALL_STATUS

--- a/modify_members_service.sh
+++ b/modify_members_service.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Modify MembersService.cs to use fully qualified Member type
+
+FILE_PATH="src/ClickUp.Api.Client/Services/MembersService.cs"
+
+# Ensure the Models.Entities using is present for Enumerable.Empty<Member>() if Member is from there,
+# but the target type is from Models.ResponseModels.Members.Member
+# The current code uses Enumerable.Empty<Member>() which will be replaced.
+
+# Replace the return type and Enumerable.Empty for GetTaskMembersAsync
+sed -i 's/public async Task<IEnumerable<Member>> GetTaskMembersAsync/public async Task<IEnumerable<ClickUp.Api.Client.Models.ResponseModels.Members.Member>> GetTaskMembersAsync/' "$FILE_PATH"
+sed -i 's/return response?.Members ?? Enumerable.Empty<Member>();/return response?.Members ?? Enumerable.Empty<ClickUp.Api.Client.Models.ResponseModels.Members.Member>();/' "$FILE_PATH"
+
+# Replace the return type and Enumerable.Empty for GetListMembersAsync
+sed -i 's/public async Task<IEnumerable<Member>> GetListMembersAsync/public async Task<IEnumerable<ClickUp.Api.Client.Models.ResponseModels.Members.Member>> GetListMembersAsync/' "$FILE_PATH"
+# The previous sed for Enumerable.Empty<Member>() might have already fixed the second one if it was identical,
+# but we make sure by targeting the specific context if needed.
+# However, the line is identical, so the previous sed should cover it.
+# If GetListMembersAsync had a slightly different return line, a more specific sed would be needed.
+# For now, assuming the line "return response?.Members ?? Enumerable.Empty<Member>();" is the same for both.
+
+# Verify the changes (optional, but good for debugging)
+echo "--- Modified Content of $FILE_PATH ---"
+cat "$FILE_PATH"
+echo "--- End of Content ---"
+
+# Check if sed command was successful (basic check)
+if grep -q "IEnumerable<ClickUp.Api.Client.Models.ResponseModels.Members.Member>" "$FILE_PATH"; then
+  echo "Successfully modified $FILE_PATH."
+  exit 0
+else
+  echo "Failed to modify $FILE_PATH as expected."
+  exit 1
+fi

--- a/modify_task_relationships_service.sh
+++ b/modify_task_relationships_service.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Modify TaskRelationshipsService.cs to fix AddTaskLinkAsync return
+
+FILE_PATH="src/ClickUp.Api.Client/Services/TaskRelationshipsService.cs"
+METHOD_SIGNATURE="public async Task<CuTask?> AddTaskLinkAsync("
+TARGET_RETURN_LINE_PATTERN="return response;"
+REPLACEMENT_RETURN_LINE="return response?.Task;"
+
+# Check if the method signature exists in the file
+if grep -q "$METHOD_SIGNATURE" "$FILE_PATH"; then
+    # Use sed to replace the return statement within the AddTaskLinkAsync method
+    # This pattern looks for the method signature, then within the block defined by { ... }
+    # it replaces "return response;"
+    sed -i "/${METHOD_SIGNATURE}/,/^ *}/s/${TARGET_RETURN_LINE_PATTERN}/${REPLACEMENT_RETURN_LINE}/" "$FILE_PATH"
+
+    echo "Attempted to modify return statement in AddTaskLinkAsync in $FILE_PATH."
+
+    # Verify the change for AddTaskLinkAsync
+    # We need to check if the specific line is now present within the method context
+    # A simple grep might find it elsewhere if the pattern is too generic.
+    # For now, a direct grep for the replaced line is a good first check.
+    if grep -q "$REPLACEMENT_RETURN_LINE" "$FILE_PATH"; then
+        echo "Successfully modified AddTaskLinkAsync in $FILE_PATH."
+        exit 0
+    else
+        echo "Failed to verify modification in AddTaskLinkAsync in $FILE_PATH. The line '$REPLACEMENT_RETURN_LINE' was not found."
+        # Optionally, print the method block to see what happened
+        echo "--- Method Block for AddTaskLinkAsync after sed ---"
+        sed -n "/${METHOD_SIGNATURE}/,/^ *}/p" "$FILE_PATH"
+        echo "--- End of Method Block ---"
+        exit 1
+    fi
+else
+    echo "Could not find method signature '$METHOD_SIGNATURE' in $FILE_PATH."
+    exit 1
+fi

--- a/src/ClickUp.Api.Client/Services/MembersService.cs
+++ b/src/ClickUp.Api.Client/Services/MembersService.cs
@@ -28,23 +28,23 @@ namespace ClickUp.Api.Client.Services
         }
 
         /// <inheritdoc />
-        public async Task<IEnumerable<Member>> GetTaskMembersAsync(
+        public async Task<IEnumerable<ClickUp.Api.Client.Models.ResponseModels.Members.Member>> GetTaskMembersAsync(
             string taskId,
             CancellationToken cancellationToken = default)
         {
             var endpoint = $"task/{taskId}/member";
             var response = await _apiConnection.GetAsync<GetMembersResponse>(endpoint, cancellationToken); // API returns {"members": [...]}
-            return response?.Members ?? Enumerable.Empty<Member>();
+            return response?.Members ?? Enumerable.Empty<ClickUp.Api.Client.Models.ResponseModels.Members.Member>();
         }
 
         /// <inheritdoc />
-        public async Task<IEnumerable<Member>> GetListMembersAsync(
+        public async Task<IEnumerable<ClickUp.Api.Client.Models.ResponseModels.Members.Member>> GetListMembersAsync(
             string listId,
             CancellationToken cancellationToken = default)
         {
             var endpoint = $"list/{listId}/member";
             var response = await _apiConnection.GetAsync<GetMembersResponse>(endpoint, cancellationToken); // API returns {"members": [...]}
-            return response?.Members ?? Enumerable.Empty<Member>();
+            return response?.Members ?? Enumerable.Empty<ClickUp.Api.Client.Models.ResponseModels.Members.Member>();
         }
     }
 }

--- a/src/ClickUp.Api.Client/Services/TaskRelationshipsService.cs
+++ b/src/ClickUp.Api.Client/Services/TaskRelationshipsService.cs
@@ -137,7 +137,7 @@ namespace ClickUp.Api.Client.Services
             // Add CuTask Link API is POST and returns the task.
             // It does not take a request body. So we send an empty object.
             var response = await _apiConnection.PostAsync<object, GetTaskResponse>(endpoint, new { }, cancellationToken);
-            return response;
+            return response?.Task;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Here's what I've done so far:
1. I set up the .NET 9 SDK environment.
2. I performed an initial build, which identified 18 compilation errors (primarily CS0535 and CS0738) and 76 warnings.
3. I reviewed IApiConnection.cs to understand the HTTP interaction contract.
4. I attempted fixes based on simulated errors:
    - I investigated AttachmentsService.cs and CustomFieldsService.cs.
    - I modified MembersService.cs to use fully qualified type names for the Member DTO in method return types. This did not change the build error count.
    - I modified TaskRelationshipsService.cs to correct a potential internal type mismatch in the AddTaskLinkAsync method (return response?.Task;). This also did not change the build error count.

Current Status:
The project still has 18 build errors and 76 warnings. The primary challenge has been accurately identifying the specific cause of the errors without direct access to the full, continuous build log output after each change, leading to fixes based on simulations that may not have targeted the root causes of the 18 blocking errors.

I was planning to proceed by meticulously analyzing the actual build errors from the last build attempt and applying targeted fixes to service implementations and DTOs as needed. However, as this is the last turn, I am presenting the current state.