### PR TITLE
feat: Implement AttachmentsService.CreateTaskAttachmentAsync and add …

### DIFF
--- a/src/ClickUp.Api.Client.Tests/ServiceTests/AttachmentsServiceTests.cs
+++ b/src/ClickUp.Api.Client.Tests/ServiceTests/AttachmentsServiceTests.cs
@@ -1,0 +1,157 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickUp.Api.Client.Abstractions.Http;
+using ClickUp.Api.Client.Models.Entities.Attachments; // Corrected Namespace
+using ClickUp.Api.Client.Services;
+using Moq;
+using Xunit;
+using System.Collections.Generic; // For List<string>
+
+namespace ClickUp.Api.Client.Tests.ServiceTests
+{
+    public class AttachmentsServiceTests
+    {
+        private readonly Mock<IApiConnection> _mockApiConnection;
+        private readonly AttachmentsService _attachmentsService;
+
+        public AttachmentsServiceTests()
+        {
+            _mockApiConnection = new Mock<IApiConnection>();
+            _attachmentsService = new AttachmentsService(_mockApiConnection.Object);
+        }
+
+        [Fact]
+        public async Task CreateTaskAttachmentAsync_ValidInput_CallsApiConnectionPostMultipartAsync()
+        {
+            // Arrange
+            var taskId = "test-task-id";
+            var customTaskIds = false;
+            string? teamId = null;
+            var fileName = "test-file.txt";
+            var fileContent = "This is a test file.";
+            using var memoryStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(fileContent));
+
+            var expectedAttachment = new Attachment(
+                Id: "generated-id",
+                Version: "1",
+                Date: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                Title: fileName,
+                Extension: "txt",
+                ThumbnailSmall: "http://example.com/thumb_small.txt",
+                ThumbnailLarge: "http://example.com/thumb_large.txt",
+                Url: "http://example.com/url.txt",
+                Orientation: null,
+                Type: null,
+                Source: null,
+                EmailFrom: null,
+                EmailTo: null,
+                EmailCc: null,
+                EmailReplyTo: null,
+                EmailDate: null,
+                EmailSubject: null,
+                EmailPreview: null,
+                EmailTextContent: null,
+                EmailHtmlContentId: null,
+                EmailAttachmentsCount: null,
+                User: null
+            );
+
+            _mockApiConnection.Setup(x => x.PostMultipartAsync<Attachment>(
+                    It.IsAny<string>(),
+                    It.IsAny<MultipartFormDataContent>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedAttachment);
+
+            // Act
+            var result = await _attachmentsService.CreateTaskAttachmentAsync(
+                taskId,
+                memoryStream,
+                fileName,
+                customTaskIds,
+                teamId,
+                CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(expectedAttachment.Id, result.Id);
+            Assert.Equal(expectedAttachment.Title, result.Title);
+
+            _mockApiConnection.Verify(x => x.PostMultipartAsync<Attachment>(
+                $"task/{taskId}/attachment?custom_task_ids=false",
+                It.IsAny<MultipartFormDataContent>(), // Simplified check for unit test
+                CancellationToken.None), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateTaskAttachmentAsync_WithCustomTaskIdsAndTeamId_BuildsCorrectEndpoint()
+        {
+            // Arrange
+            var taskId = "custom-task-id";
+            var customTaskIds = true;
+            var teamId = "test-team-id";
+            var fileName = "test-file.txt";
+            var fileContent = "This is a test file.";
+            using var memoryStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(fileContent));
+
+            var expectedAttachment = new Attachment(
+                Id: "id", Version: "v", Date: 123, Title: "title", Extension: "ext", ThumbnailSmall: "ts",
+                ThumbnailLarge: "tl", Url: "url", Orientation: null, Type: null, Source: null,
+                EmailFrom: null, EmailTo: null, EmailCc: null, EmailReplyTo: null, EmailDate: null,
+                EmailSubject: null, EmailPreview: null, EmailTextContent: null, EmailHtmlContentId: null,
+                EmailAttachmentsCount: null, User: null
+            );
+
+
+            _mockApiConnection.Setup(x => x.PostMultipartAsync<Attachment>(
+                    It.IsAny<string>(),
+                    It.IsAny<MultipartFormDataContent>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedAttachment);
+
+            // Act
+            await _attachmentsService.CreateTaskAttachmentAsync(
+                taskId,
+                memoryStream,
+                fileName,
+                customTaskIds,
+                teamId,
+                CancellationToken.None);
+
+            // Assert
+            _mockApiConnection.Verify(x => x.PostMultipartAsync<Attachment>(
+                $"task/{taskId}/attachment?custom_task_ids=true&team_id={teamId}",
+                It.IsAny<MultipartFormDataContent>(),
+                CancellationToken.None), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateTaskAttachmentAsync_ApiConnectionReturnsNull_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var taskId = "test-task-id";
+            var fileName = "test-file.txt";
+            var fileContent = "This is a test file.";
+            using var memoryStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(fileContent));
+
+            _mockApiConnection.Setup(x => x.PostMultipartAsync<Attachment>(
+                    It.IsAny<string>(),
+                    It.IsAny<MultipartFormDataContent>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Attachment?)null); // Added ? for nullable return
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                _attachmentsService.CreateTaskAttachmentAsync(
+                    taskId,
+                    memoryStream,
+                    fileName,
+                    false,
+                    null,
+                    CancellationToken.None)
+            );
+        }
+    }
+}

--- a/src/ClickUp.Api.Client.Tests/ServiceTests/TaskServiceTests.cs
+++ b/src/ClickUp.Api.Client.Tests/ServiceTests/TaskServiceTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickUp.Api.Client.Abstractions.Http;
+using ClickUp.Api.Client.Models.Common; // For Status, Priority
+using ClickUp.Api.Client.Models.Entities; // For CustomFieldValue
+using ClickUp.Api.Client.Models.Entities.Tasks;
+using ClickUp.Api.Client.Models.Entities.Users;
+using ClickUp.Api.Client.Models.Entities.Checklists; // For Checklist
+using ClickUp.Api.Client.Models.Entities.Tags;       // For Tag
+using ClickUp.Api.Client.Services;
+using Moq;
+using Xunit;
+
+namespace ClickUp.Api.Client.Tests.ServiceTests
+{
+    public class TaskServiceTests
+    {
+        private readonly Mock<IApiConnection> _mockApiConnection;
+        private readonly TaskService _taskService;
+
+        public TaskServiceTests()
+        {
+            _mockApiConnection = new Mock<IApiConnection>();
+            _taskService = new TaskService(_mockApiConnection.Object);
+        }
+
+        private CuTask CreateSampleTask(string taskId = "sample-task-id")
+        {
+            return new CuTask(
+                Id: taskId,
+                CustomId: "custom-id",
+                CustomItemId: 1,
+                Name: "Sample Task Name",
+                TextContent: "Sample text content",
+                Description: "Sample markdown description",
+                MarkdownDescription: "Sample markdown description",
+                Status: new Models.Common.Status("open", "Open", 0, "open"), // Corrected namespace
+                OrderIndex: "1.0",
+                DateCreated: "1678886400000", // Example timestamp
+                DateUpdated: "1678886400000",
+                DateClosed: null,
+                Archived: false,
+                Creator: new User(1, "Test User", "test@example.com", "#FFFFFF", "http://example.com/pic.jpg", "TU", null), // Corrected constructor
+                Assignees: new List<User>(),
+                GroupAssignees: new List<UserGroup>(),
+                Watchers: new List<User>(),
+                Checklists: new List<Checklist>(),
+                Tags: new List<Tag>(),
+                Parent: null,
+                Priority: new Models.Common.Priority { Id = "1", PriorityValue = "High", Color = "#FF0000", OrderIndex = "1" },
+                DueDate: null,
+                StartDate: null,
+                Points: null,
+                TimeEstimate: null,
+                TimeSpent: null,
+                CustomFields: new List<CustomFieldValue>(), // Corrected namespace
+                Dependencies: new List<Dependency>(),
+                LinkedTasks: new List<TaskLink>(),
+                TeamId: "workspace-id",
+                Url: $"http://example.com/task/{taskId}",
+                Sharing: null,
+                PermissionLevel: "read",
+                List: new TaskListReference("list-id", "Sample List", true),
+                Folder: new TaskFolderReference("folder-id", "Sample Folder", true),
+                Space: new TaskSpaceReference("space-id"),
+                Project: new TaskFolderReference("project-id", "Sample Project", true) // Assuming project is like folder
+            );
+        }
+
+        [Fact]
+        public async Task GetTaskAsync_ValidTaskId_ReturnsTask()
+        {
+            // Arrange
+            var taskId = "test-task-123";
+            var expectedTask = CreateSampleTask(taskId);
+
+            _mockApiConnection
+                .Setup(x => x.GetAsync<CuTask>(It.Is<string>(s => s.StartsWith($"task/{taskId}")), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedTask);
+
+            // Act
+            var result = await _taskService.GetTaskAsync(taskId, null, null, null, null, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(taskId, result.Id);
+            Assert.Equal(expectedTask.Name, result.Name);
+            _mockApiConnection.Verify(x => x.GetAsync<CuTask>($"task/{taskId}", CancellationToken.None), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetTaskAsync_WithAllQueryParameters_BuildsCorrectEndpoint()
+        {
+            // Arrange
+            var taskId = "test-task-456";
+            var customTaskIds = true;
+            var teamId = "team-abc";
+            var includeSubtasks = true;
+            var includeMarkdownDescription = true;
+            var expectedTask = CreateSampleTask(taskId);
+
+            _mockApiConnection
+                .Setup(x => x.GetAsync<CuTask>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedTask);
+
+            var expectedEndpoint = $"task/{taskId}?custom_task_ids=true&team_id={teamId}&include_subtasks=true&include_markdown_description=true";
+
+            // Act
+            await _taskService.GetTaskAsync(taskId, customTaskIds, teamId, includeSubtasks, includeMarkdownDescription, CancellationToken.None);
+
+            // Assert
+            _mockApiConnection.Verify(x => x.GetAsync<CuTask>(expectedEndpoint, CancellationToken.None), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetTaskAsync_WithSomeQueryParameters_BuildsCorrectEndpoint()
+        {
+            // Arrange
+            var taskId = "test-task-789";
+            bool? customTaskIds = null; // Not provided
+            var teamId = "team-xyz";
+            var includeSubtasks = true;
+            bool? includeMarkdownDescription = null; // Not provided
+            var expectedTask = CreateSampleTask(taskId);
+
+            _mockApiConnection
+                .Setup(x => x.GetAsync<CuTask>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedTask);
+
+            var expectedEndpoint = $"task/{taskId}?team_id={teamId}&include_subtasks=true";
+
+            // Act
+            await _taskService.GetTaskAsync(taskId, customTaskIds, teamId, includeSubtasks, includeMarkdownDescription, CancellationToken.None);
+
+            // Assert
+            _mockApiConnection.Verify(x => x.GetAsync<CuTask>(expectedEndpoint, CancellationToken.None), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetTaskAsync_ApiConnectionReturnsNull_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var taskId = "non-existent-task";
+            _mockApiConnection
+                .Setup(x => x.GetAsync<CuTask>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((CuTask?)null); // Added ? for nullable return
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                _taskService.GetTaskAsync(taskId, null, null, null, null, CancellationToken.None)
+            );
+        }
+
+        [Fact]
+        public async Task GetTaskAsync_ApiConnectionThrowsException_PropagatesException()
+        {
+            // Arrange
+            var taskId = "error-task";
+            var apiException = new HttpRequestException("API error");
+            _mockApiConnection
+                .Setup(x => x.GetAsync<CuTask>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(apiException);
+
+            // Act & Assert
+            var actualException = await Assert.ThrowsAsync<HttpRequestException>(() =>
+                _taskService.GetTaskAsync(taskId, null, null, null, null, CancellationToken.None)
+            );
+            Assert.Equal(apiException.Message, actualException.Message);
+        }
+    }
+}

--- a/src/ClickUp.Api.Client/DependencyInjection.cs
+++ b/src/ClickUp.Api.Client/DependencyInjection.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Net.Http.Headers;
+using ClickUp.Api.Client.Abstractions.Http;
+using ClickUp.Api.Client.Abstractions.Services;
+using ClickUp.Api.Client.Http;
+using ClickUp.Api.Client.Services;
+using Microsoft.Extensions.DependencyInjection; // Required for IServiceCollection, AddHttpClient, etc.
+
+namespace ClickUp.Api.Client
+{
+    /// <summary>
+    /// Extension methods for setting up ClickUp API client services in an <see cref="IServiceCollection"/>.
+    /// </summary>
+    public static class DependencyInjection
+    {
+        /// <summary>
+        /// Adds the ClickUp API client services to the specified <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+        /// <param name="apiToken">The ClickUp API token.</param>
+        /// <param name="userAgent">Optional. The user agent string to use for requests. Defaults to "ClickUp.Net.Client".</param>
+        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        public static IServiceCollection AddClickUpApiClient(
+            this IServiceCollection services,
+            string apiToken,
+            string userAgent = "ClickUp.Net.Client/1.0") // Default User-Agent
+        {
+            if (string.IsNullOrWhiteSpace(apiToken))
+            {
+                throw new ArgumentException("API token cannot be null or whitespace.", nameof(apiToken));
+            }
+
+            // Configure HttpClient for IApiConnection
+            services.AddHttpClient<IApiConnection, ApiConnection>(client =>
+            {
+                client.BaseAddress = new Uri("https://api.clickup.com/api/v2/");
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(apiToken); // This is for Personal API Token. OAuth would be different.
+                client.DefaultRequestHeaders.UserAgent.ParseAdd(userAgent);
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            });
+            // In a more complex scenario with Polly, DelegatingHandlers for auth, etc.,
+            // this is where those would be added via .AddHttpMessageHandler()
+
+            // Register services
+            services.AddScoped<IAttachmentsService, AttachmentsService>();
+            services.AddScoped<IAuthorizationService, AuthorizationService>();
+            // services.AddScoped<IChatsService, ChatsService>();
+            // services.AddScoped<IChecklistsService, ChecklistsService>();
+            // services.AddScoped<ICommentsService, CommentsService>();
+            services.AddScoped<ICustomFieldsService, CustomFieldsService>();
+            // services.AddScoped<ICustomTaskTypesService, CustomTaskTypesService>();
+            services.AddScoped<IFoldersService, FoldersService>();
+            services.AddScoped<IGoalsService, GoalsService>();
+            // services.AddScoped<IGroupsService, GroupsService>();
+            // services.AddScoped<IGuestsService, GuestsService>();
+            services.AddScoped<IListsService, ListsService>();
+            // services.AddScoped<IMembersService, MembersService>();
+            // services.AddScoped<IRolesService, RolesService>();
+            // services.AddScoped<ISharedHierarchyService, SharedHierarchyService>();
+            services.AddScoped<ISpacesService, SpacesService>();
+            services.AddScoped<ITagsService, TagsService>();
+            // services.AddScoped<ITaskChecklistsService, TaskChecklistsService>();
+            // services.AddScoped<ITaskRelationshipsService, TaskRelationshipsService>();
+            services.AddScoped<ITasksService, TaskService>(); // Corrected from TasksService
+            // services.AddScoped<ITeamsService, TeamsService>(); // Assuming ITeamsService is for User Groups / ClickUp "Teams"
+            // services.AddScoped<ITemplatesService, TemplatesService>();
+            services.AddScoped<ITimeTrackingService, TimeTrackingService>();
+            // services.AddScoped<ITimeTrackingLegacyService, TimeTrackingLegacyService>();
+            services.AddScoped<IUsersService, UsersService>();
+            services.AddScoped<IViewsService, ViewsService>();
+            services.AddScoped<IWebhooksService, WebhooksService>();
+            // Add other services as they are created/refactored
+
+            return services;
+        }
+    }
+}

--- a/src/ClickUp.Api.Client/Helpers/JsonSerializerOptionsHelper.cs
+++ b/src/ClickUp.Api.Client/Helpers/JsonSerializerOptionsHelper.cs
@@ -17,11 +17,12 @@ namespace ClickUp.Api.Client.Helpers
         {
             Options = new JsonSerializerOptions
             {
-                PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+                PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower, // For serializing C# PascalCase to snake_case
+                PropertyNameCaseInsensitive = true, // For deserializing snake_case from API to C# PascalCase
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                 Converters =
                 {
-                    new JsonStringEnumConverter(JsonNamingPolicy.SnakeCaseLower) // Or CamelCase if API prefers that for enums
+                    new JsonStringEnumConverter(JsonNamingPolicy.SnakeCaseLower) // Assumes enums are also snake_case in API
                 }
             };
 


### PR DESCRIPTION
…unit tests

Implemented the CreateTaskAttachmentAsync method in AttachmentsService to support file uploads to tasks. Added comprehensive unit tests for AttachmentsService.CreateTaskAttachmentAsync. Added comprehensive unit tests for the existing TaskService.GetTaskAsync method.

Also includes:
- Creation of DependencyInjection.cs for centralized service registration.
- Configuration of HttpClient via IHttpClientFactory with base ClickUp API settings.
- Minor update to JsonSerializerOptionsHelper for case-insensitive property name handling.
- Corrections to DTO references and instantiations within the newly added test files.
- Temporary commenting out of unimplemented services in DependencyInjection.cs to allow the build to pass for focused testing.