### PR TITLE
Implement AttachmentsService and Verify AuthorizationService

### DIFF
--- a/src/ClickUp.Api.Client.Abstractions/Services/IAttachmentsService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/IAttachmentsService.cs
@@ -2,8 +2,8 @@
 using System.IO; // Required for Stream
 using System.Threading;
 using System.Threading.Tasks;
-using ClickUp.Api.Client.Models.Entities;
-using ClickUp.Api.Client.Models.Entities.Attachments; // Assuming Attachment DTO is here
+using ClickUp.Api.Client.Models.Entities; // May not be needed if Attachment is not directly used
+using ClickUp.Api.Client.Models.Responses.Attachments; // Changed to use the new response DTO
 
 namespace ClickUp.Api.Client.Abstractions.Services
 {
@@ -26,8 +26,8 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="customTaskIds">Optional. If true, references task by custom task id.</param>
         /// <param name="teamId">Optional. Workspace ID (formerly team_id), required if customTaskIds is true.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A task that represents the asynchronous operation. The task result contains details of the created <see cref="Attachment"/>.</returns>
-        Task<Attachment> CreateTaskAttachmentAsync(
+        /// <returns>A task that represents the asynchronous operation. The task result contains details of the created attachment response <see cref="CreateTaskAttachmentResponse"/>.</returns>
+        Task<CreateTaskAttachmentResponse> CreateTaskAttachmentAsync(
             string taskId,
             Stream fileStream,
             string fileName,

--- a/src/ClickUp.Api.Client.Models/Entities/Users/User.cs
+++ b/src/ClickUp.Api.Client.Models/Entities/Users/User.cs
@@ -25,6 +25,22 @@ public record class User
     [property: JsonPropertyName("initials")]
     string? Initials,
 
+    // Fields from User9 schema in OpenAPI spec
+    [property: JsonPropertyName("role")]
+    int? Role = null,
+
+    [property: JsonPropertyName("custom_role")]
+    CustomRole? CustomRole = null,
+
+    [property: JsonPropertyName("last_active")]
+    string? LastActive = null, // String representation of Unix ms timestamp
+
+    [property: JsonPropertyName("date_joined")]
+    string? DateJoined = null, // String representation of Unix ms timestamp
+
+    [property: JsonPropertyName("date_invited")]
+    string? DateInvited = null, // String representation of Unix ms timestamp
+
     [property: JsonPropertyName("profileInfo")]
-    ProfileInfo? ProfileInfo // Added new property
+    ProfileInfo? ProfileInfo = null
 );

--- a/src/ClickUp.Api.Client.Models/Responses/Attachments/CreateTaskAttachmentResponse.cs
+++ b/src/ClickUp.Api.Client.Models/Responses/Attachments/CreateTaskAttachmentResponse.cs
@@ -1,0 +1,37 @@
+using System.Text.Json.Serialization;
+using ClickUp.Api.Client.Models.Entities.Users; // Assuming User10 is similar to existing User model
+using System.Collections.Generic; // For List if needed for properties like email_data
+
+namespace ClickUp.Api.Client.Models.Responses.Attachments
+{
+    // Based on OpenAPI spec "CreateAttachmentresponse"
+    public record CreateTaskAttachmentResponse
+    (
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("version")] string Version,
+        [property: JsonPropertyName("date")] long Date, // Unix timestamp
+        [property: JsonPropertyName("title")] string Title,
+        [property: JsonPropertyName("extension")] string Extension,
+        [property: JsonPropertyName("thumbnail_small")] string? ThumbnailSmall,
+        [property: JsonPropertyName("thumbnail_large")] string? ThumbnailLarge,
+        [property: JsonPropertyName("url")] string Url,
+        [property: JsonPropertyName("url_w_query")] string UrlWQuery,
+        [property: JsonPropertyName("url_w_host")] string UrlWHost,
+        [property: JsonPropertyName("is_folder")] bool IsFolder,
+        [property: JsonPropertyName("parent_id")] string ParentId,
+        [property: JsonPropertyName("size")] long Size, // Assuming long for size in bytes
+        [property: JsonPropertyName("total_comments")] int TotalComments,
+        [property: JsonPropertyName("resolved_comments")] int ResolvedComments,
+        [property: JsonPropertyName("user")] User User, // Assuming User10 from spec maps to our User model
+        [property: JsonPropertyName("deleted")] bool Deleted,
+        [property: JsonPropertyName("orientation")] object? Orientation, // Define a specific model if structure is known
+        [property: JsonPropertyName("type")] int Type,
+        [property: JsonPropertyName("source")] int Source,
+        [property: JsonPropertyName("email_data")] object? EmailData, // Define a specific model if structure is known
+        [property: JsonPropertyName("resource_id")] string ResourceId
+    );
+
+    // TODO: Define specific models for Orientation and EmailData if their structure is known and needed.
+    // For User, assuming ClickUp.Api.Client.Models.Entities.Users.User is compatible with User10.
+    // If User10 has a different structure, a separate User10 model might be needed.
+}


### PR DESCRIPTION
This commit includes the following changes:

**1. AttachmentsService Implementation:**
- Verified and refined the `CreateTaskAttachmentAsync` method in `AttachmentsService.cs`.
- Created a new DTO `CreateTaskAttachmentResponse.cs` based on the OpenAPI specification to ensure all fields returned by the API are captured.
- Updated `IAttachmentsService.cs` and `AttachmentsService.cs` to use `CreateTaskAttachmentResponse`.
- Corrected the construction of `MultipartFormDataContent` in `CreateTaskAttachmentAsync` to include `filename` as a separate form field, as required by the ClickUp API, in addition to providing it in the `Content-Disposition` of the file stream.
- Updated `AttachmentsServiceTests.cs`:
    - Modified mock setups to use `CreateTaskAttachmentResponse`.
    - Adjusted `User` object instantiation within tests to align with its current constructor after recent modifications (related to `AuthorizationService` work).
- Ensured the project builds successfully and all unit tests, including those for `AttachmentsService`, pass.

**2. AuthorizationService Verification & User Model Update:**
- Reviewed existing implementations of `GetAuthorizedUserAsync`, `GetAuthorizedWorkspacesAsync`, and `GetAccessTokenAsync` in `AuthorizationService.cs`.
- Updated the shared `User.cs` model to include fields (`role`, `custom_role`, `last_active`, `date_joined`, `date_invited`) from the OpenAPI `User9` schema. This enhances the `GetAuthorizedUserAsync` method's ability to return a more complete user object.
- To prevent breaking changes in other services (e.g., `UsersService.cs`) that also instantiate `User` objects, the new parameters in the `User.cs` primary constructor were made optional by providing default `null` values.
- Verified that DTOs related to `AuthorizationService` methods are generally consistent with the OpenAPI specification.
- Ensured the project builds successfully and all unit tests pass after these model changes.

The work prepares for further service implementations, starting with `ChatService`.