### PR TITLE
Docs: Add XML exception documentation to service interfaces (Part 1)

### DIFF
--- a/src/ClickUp.Api.Client.Abstractions/Services/IAttachmentsService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/IAttachmentsService.cs
@@ -27,6 +27,8 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="teamId">Optional. Workspace ID (formerly team_id), required if customTaskIds is true.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains details of the created attachment response <see cref="CreateTaskAttachmentResponse"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="taskId"/>, <paramref name="fileStream"/>, or <paramref name="fileName"/> is null or empty/whitespace.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails. Common derived types include <see cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException"/>, <see cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiRateLimitException"/>, or <see cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiRequestException"/>.</exception>
         Task<CreateTaskAttachmentResponse> CreateTaskAttachmentAsync(
             string taskId,
             Stream fileStream,

--- a/src/ClickUp.Api.Client.Abstractions/Services/IAuthorizationService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/IAuthorizationService.cs
@@ -32,6 +32,8 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="code">Authorization code received from redirect.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="GetAccessTokenResponse"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="clientId"/>, <paramref name="clientSecret"/>, or <paramref name="code"/> is null or empty/whitespace.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails, e.g., due to invalid credentials or an expired/invalid code. Common derived types include <see cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException"/> or <see cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiRequestException"/>.</exception>
         Task<GetAccessTokenResponse> GetAccessTokenAsync(
             string clientId,
             string clientSecret,
@@ -43,6 +45,8 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// </summary>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the authorized <see cref="User"/>'s details.</returns>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the current session is not authenticated (e.g., missing or invalid API token).</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons. See inner exception and properties for details.</exception>
         Task<User> GetAuthorizedUserAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -50,6 +54,8 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// </summary>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains a list of authorized <see cref="ClickUpWorkspace"/> objects.</returns>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the current session is not authenticated (e.g., missing or invalid API token).</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons. See inner exception and properties for details.</exception>
         Task<IEnumerable<ClickUpWorkspace>> GetAuthorizedWorkspacesAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/ClickUp.Api.Client.Abstractions/Services/IChatService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/IChatService.cs
@@ -27,6 +27,9 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="roomTypes">Optional. Types of Channels to return (e.g., "CHANNEL", "DM", "GROUP_DM").</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A <see cref="ChatChannelPaginatedResponse"/> object containing a paginated list of channels and next cursor.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access the workspace.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<ChatChannelPaginatedResponse> GetChatChannelsAsync(
             string workspaceId,
             string? descriptionFormat = null,
@@ -45,6 +48,9 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="createChatChannelRequest">Details for creating the Channel.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The created or existing <see cref="ChatChannel"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="createChatChannelRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to perform this action.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<ChatChannel> CreateChatChannelAsync(
             string workspaceId,
             ChatCreateChatChannelRequest createChatChannelRequest,
@@ -57,6 +63,9 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="createLocationChatChannelRequest">Details for creating the location-based Channel.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The created or existing <see cref="ChatChannel"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="createLocationChatChannelRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to perform this action.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<ChatChannel> CreateLocationChatChannelAsync(
             string workspaceId,
             ChatCreateLocationChatChannelRequest createLocationChatChannelRequest,
@@ -69,6 +78,9 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="createDirectMessageChatChannelRequest">User IDs for the DM/Group DM.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The created or existing Direct Message <see cref="ChatChannel"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="createDirectMessageChatChannelRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to perform this action.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<ChatChannel> CreateDirectMessageChatChannelAsync(
             string workspaceId,
             ChatCreateDirectMessageChatChannelRequest createDirectMessageChatChannelRequest,
@@ -82,6 +94,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="descriptionFormat">Optional. Format of the Channel Description.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Details of the <see cref="ChatChannel"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="channelId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the channel with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access this channel.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<ChatChannel> GetChatChannelAsync(
             string workspaceId,
             string channelId,
@@ -96,6 +112,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="updateChatChannelRequest">Details for updating the Channel.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The updated <see cref="ChatChannel"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/>, <paramref name="channelId"/>, or <paramref name="updateChatChannelRequest"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the channel with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to update this channel.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<ChatChannel> UpdateChatChannelAsync(
             string workspaceId,
             string channelId,
@@ -109,6 +129,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="channelId">The ID of the Channel to delete.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="channelId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the channel with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to delete this channel.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task DeleteChatChannelAsync(
             string workspaceId,
             string channelId,
@@ -123,6 +147,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="limit">Optional. Maximum number of results per page.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A <see cref="GetChatUsersResponse"/> object containing a paginated list of channel followers (<see cref="ChatUser"/>) and next cursor.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="channelId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the channel with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access this information.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<GetChatUsersResponse> GetChatChannelFollowersAsync(
             string workspaceId,
             string channelId,
@@ -139,6 +167,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="limit">Optional. Maximum number of results per page.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A <see cref="GetChatUsersResponse"/> object containing a paginated list of channel members (<see cref="ChatUser"/>) and next cursor.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="channelId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the channel with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access this information.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<GetChatUsersResponse> GetChatChannelMembersAsync(
             string workspaceId,
             string channelId,
@@ -158,6 +190,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="contentFormat">Optional. Format of the message content.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A <see cref="GetChatMessagesResponse"/> object containing a paginated list of messages (<see cref="ChatMessage"/>) and next cursor.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="channelId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the channel with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access messages in this channel.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<GetChatMessagesResponse> GetChatMessagesAsync(
             string workspaceId,
             string channelId,
@@ -174,6 +210,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="createMessageRequest">Details of the message to send.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The created <see cref="ChatMessage"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/>, <paramref name="channelId"/>, or <paramref name="createMessageRequest"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the channel with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to send messages to this channel.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<ChatMessage> CreateChatMessageAsync(
             string workspaceId,
             string channelId,
@@ -188,6 +228,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="updateMessageRequest">Details for updating the message.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The updated <see cref="ChatMessage"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/>, <paramref name="messageId"/>, or <paramref name="updateMessageRequest"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the message with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to update this message.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<ChatMessage> UpdateChatMessageAsync(
             string workspaceId,
             string messageId,
@@ -201,6 +245,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="messageId">The ID of the message to delete.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="messageId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the message with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to delete this message.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task DeleteChatMessageAsync(
             string workspaceId,
             string messageId,
@@ -214,6 +262,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="createReplyRequest">Details of the reply message to send.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The created reply <see cref="ChatMessage"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/>, <paramref name="messageId"/>, or <paramref name="createReplyRequest"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the parent message with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to reply to this message.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<ChatMessage> CreateReplyMessageAsync(
             string workspaceId,
             string messageId,
@@ -230,6 +282,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="contentFormat">Optional. Format of the message content.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A <see cref="GetChatMessagesResponse"/> object containing a paginated list of reply messages (<see cref="ChatMessage"/>) and next cursor.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="messageId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the parent message with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access replies for this message.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<GetChatMessagesResponse> GetChatMessageRepliesAsync(
             string workspaceId,
             string messageId,
@@ -249,6 +305,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="limit">Optional. Maximum number of results per page.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A <see cref="GetChatReactionsResponse"/> object containing a paginated list of reactions (<see cref="ChatReaction"/>) and next cursor.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="messageId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the message with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access reactions for this message.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<GetChatReactionsResponse> GetChatMessageReactionsAsync(
             string workspaceId,
             string messageId,
@@ -264,6 +324,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="createReactionRequest">The reaction emoji details.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The created <see cref="ChatReaction"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/>, <paramref name="messageId"/>, or <paramref name="createReactionRequest"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the message with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to react to this message.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<ChatReaction> CreateChatReactionAsync(
             string workspaceId,
             string messageId,
@@ -278,6 +342,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="reaction">The name/emoji of the reaction to delete (e.g., ":thumbsup:").</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/>, <paramref name="messageId"/>, or <paramref name="reaction"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the message or reaction is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to delete this reaction.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task DeleteChatReactionAsync(
             string workspaceId,
             string messageId,
@@ -293,6 +361,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="limit">Optional. Maximum number of results per page.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A <see cref="GetChatUsersResponse"/> object containing a paginated list of tagged users (<see cref="ChatUser"/>) and next cursor.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="messageId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the message with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access this information.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<GetChatUsersResponse> GetChatMessageTaggedUsersAsync(
             string workspaceId,
             string messageId,

--- a/src/ClickUp.Api.Client.Abstractions/Services/ICommentService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/ICommentService.cs
@@ -36,6 +36,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="startId">Optional. Comment ID to start pagination from.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A list of <see cref="Comment"/> objects for the task.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="taskId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the task with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access comments for this task.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<IEnumerable<Comment>> GetTaskCommentsAsync(
             string taskId,
             bool? customTaskIds = null,
@@ -53,6 +57,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="teamId">Optional. Workspace ID (formerly team_id), required if customTaskIds is true.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A <see cref="CreateCommentResponse"/> object containing details of the created comment (often includes the comment ID and the comment itself).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="taskId"/> or <paramref name="createCommentRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the task with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to create a comment on this task.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<CreateCommentResponse> CreateTaskCommentAsync(
             string taskId,
             CreateCommentRequest createCommentRequest,
@@ -68,6 +76,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="startId">Optional. Comment ID to start pagination from.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A list of <see cref="Comment"/> objects for the Chat view.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="viewId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the Chat view with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access comments for this view.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<IEnumerable<Comment>> GetChatViewCommentsAsync(
             string viewId,
             long? start = null, // Changed int? to long? for Unix time ms
@@ -81,6 +93,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="createCommentRequest">Details of the comment to create.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A <see cref="CreateCommentResponse"/> object containing details of the created comment.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="viewId"/> or <paramref name="createCommentRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the Chat view with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to create a comment on this view.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<CreateCommentResponse> CreateChatViewCommentAsync(
             string viewId,
             CreateCommentRequest createCommentRequest,
@@ -94,6 +110,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="startId">Optional. Comment ID to start pagination from.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A list of <see cref="Comment"/> objects for the List.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="listId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the list with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access comments for this list.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<IEnumerable<Comment>> GetListCommentsAsync(
             string listId,
             long? start = null, // Changed int? to long? for Unix time ms
@@ -107,6 +127,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="createCommentRequest">Details of the comment to create.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A <see cref="CreateCommentResponse"/> object containing details of the created comment.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="listId"/> or <paramref name="createCommentRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the list with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to create a comment on this list.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<CreateCommentResponse> CreateListCommentAsync(
             string listId,
             CreateCommentRequest createCommentRequest,
@@ -119,6 +143,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="updateCommentRequest">Details for updating the comment.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="commentId"/> or <paramref name="updateCommentRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the comment with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to update this comment.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task UpdateCommentAsync(
             string commentId,
             UpdateCommentRequest updateCommentRequest,
@@ -130,6 +158,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="commentId">The ID of the comment to delete.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="commentId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the comment with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to delete this comment.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task DeleteCommentAsync(
             string commentId,
             CancellationToken cancellationToken = default);
@@ -140,6 +172,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="commentId">The ID of the parent comment.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A list of threaded <see cref="Comment"/> objects.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="commentId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the parent comment with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access threaded comments.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<IEnumerable<Comment>> GetThreadedCommentsAsync(
             string commentId,
             CancellationToken cancellationToken = default);
@@ -151,6 +187,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="createCommentRequest">Details of the threaded comment to create.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="commentId"/> or <paramref name="createCommentRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the parent comment with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to create a threaded comment.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task CreateThreadedCommentAsync(
             string commentId,
             CreateCommentRequest createCommentRequest,

--- a/src/ClickUp.Api.Client.Abstractions/Services/ICustomFieldsService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/ICustomFieldsService.cs
@@ -26,6 +26,10 @@ namespace ClickUp.Api.Client.Abstractions.Services // Corrected namespace
         /// <param name="listId">The ID of the List.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A list of <see cref="Field"/> objects accessible from the List.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="listId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the list with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access custom fields for this list.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<IEnumerable<Field>> GetAccessibleCustomFieldsAsync(
             string listId,
             CancellationToken cancellationToken = default);
@@ -42,6 +46,10 @@ namespace ClickUp.Api.Client.Abstractions.Services // Corrected namespace
         /// <param name="folderId">The ID of the Folder.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A list of <see cref="Field"/> objects for the Folder.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="folderId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the folder with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access custom fields for this folder.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<IEnumerable<Field>> GetFolderCustomFieldsAsync(
             string folderId,
             CancellationToken cancellationToken = default);
@@ -52,6 +60,10 @@ namespace ClickUp.Api.Client.Abstractions.Services // Corrected namespace
         /// <param name="spaceId">The ID of the Space.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A list of <see cref="Field"/> objects for the Space.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="spaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the space with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access custom fields for this space.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<IEnumerable<Field>> GetSpaceCustomFieldsAsync(
             string spaceId,
             CancellationToken cancellationToken = default);
@@ -62,6 +74,10 @@ namespace ClickUp.Api.Client.Abstractions.Services // Corrected namespace
         /// <param name="workspaceId">The ID of the Workspace (Team).</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A list of <see cref="Field"/> objects for the Workspace.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the workspace with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access custom fields for this workspace.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<IEnumerable<Field>> GetWorkspaceCustomFieldsAsync(
             string workspaceId,
             CancellationToken cancellationToken = default);
@@ -76,6 +92,11 @@ namespace ClickUp.Api.Client.Abstractions.Services // Corrected namespace
         /// <param name="teamId">Optional. Workspace ID (formerly team_id), required if customTaskIds is true.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="taskId"/>, <paramref name="fieldId"/>, or <paramref name="setFieldValueRequest"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the task or custom field with the specified IDs are not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiValidationException">Thrown if the provided value is invalid for the custom field type.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to set this custom field value.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task SetCustomFieldValueAsync(
             string taskId,
             string fieldId,
@@ -93,6 +114,10 @@ namespace ClickUp.Api.Client.Abstractions.Services // Corrected namespace
         /// <param name="teamId">Optional. Workspace ID (formerly team_id), required if customTaskIds is true.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="taskId"/> or <paramref name="fieldId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the task or custom field with the specified IDs are not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to remove this custom field value.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task RemoveCustomFieldValueAsync(
             string taskId,
             string fieldId,

--- a/src/ClickUp.Api.Client.Abstractions/Services/IDocsService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/IDocsService.cs
@@ -31,6 +31,9 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="searchDocsRequest">Parameters for searching/filtering docs.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A <see cref="SearchDocsResponse"/> object containing a list of Docs and pagination cursor.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="searchDocsRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to search docs in this workspace.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<SearchDocsResponse> SearchDocsAsync(
             string workspaceId,
             SearchDocsRequest searchDocsRequest,
@@ -43,6 +46,9 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="createDocRequest">Details for creating the Doc.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The created <see cref="Doc"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="createDocRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to create docs in this workspace.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Doc> CreateDocAsync(
             string workspaceId,
             CreateDocRequest createDocRequest,
@@ -55,6 +61,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="docId">The ID of the Doc.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Details of the <see cref="Doc"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="docId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the doc with the specified ID is not found in the workspace.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access this doc.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Doc> GetDocAsync(
             string workspaceId,
             string docId,
@@ -68,6 +78,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="maxPageDepth">Optional. Maximum depth to retrieve pages and subpages.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A list of <see cref="DocPageListingItem"/> objects.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="docId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the doc with the specified ID is not found in the workspace.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access this doc's page listing.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<IEnumerable<DocPageListingItem>> GetDocPageListingAsync(
             string workspaceId,
             string docId,
@@ -83,6 +97,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="contentFormat">Optional. Format for page content (e.g., "text/md", "application/json").</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A list of <see cref="Page"/> objects within the Doc.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="docId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the doc with the specified ID is not found in the workspace.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access pages for this doc.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<IEnumerable<Page>> GetDocPagesAsync(
             string workspaceId,
             string docId,
@@ -98,6 +116,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="createPageRequest">Details for creating the page.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The created <see cref="Page"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/>, <paramref name="docId"/>, or <paramref name="createPageRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the doc with the specified ID is not found in the workspace.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to create pages in this doc.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Page> CreatePageAsync(
             string workspaceId,
             string docId,
@@ -113,6 +135,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="contentFormat">Optional. Format for page content.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Details of the <see cref="Page"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/>, <paramref name="docId"/>, or <paramref name="pageId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the doc or page with the specified IDs are not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access this page.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Page> GetPageAsync(
             string workspaceId,
             string docId,
@@ -129,6 +155,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="updatePageRequest">Details for editing the page using <see cref="EditPageRequest"/>.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/>, <paramref name="docId"/>, <paramref name="pageId"/>, or <paramref name="updatePageRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the doc or page with the specified IDs are not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to edit this page.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task EditPageAsync(
             string workspaceId,
             string docId,

--- a/src/ClickUp.Api.Client.Abstractions/Services/IFoldersService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/IFoldersService.cs
@@ -29,6 +29,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="archived">Optional. Whether to include archived Folders.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A list of <see cref="Folder"/> objects in the Space.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="spaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the space with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access folders in this space.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<IEnumerable<Folder>> GetFoldersAsync(
             string spaceId,
             bool? archived = null,
@@ -41,6 +45,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="createFolderRequest">Details of the Folder to create.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The created <see cref="Folder"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="spaceId"/> or <paramref name="createFolderRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the space with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to create folders in this space.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Folder> CreateFolderAsync(
             string spaceId,
             CreateFolderRequest createFolderRequest,
@@ -52,6 +60,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="folderId">The ID of the Folder.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Details of the <see cref="Folder"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="folderId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the folder with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access this folder.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Folder> GetFolderAsync(
             string folderId,
             CancellationToken cancellationToken = default);
@@ -63,6 +75,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="updateFolderRequest">Details for updating the Folder.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The updated <see cref="Folder"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="folderId"/> or <paramref name="updateFolderRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the folder with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to update this folder.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Folder> UpdateFolderAsync(
             string folderId,
             UpdateFolderRequest updateFolderRequest,
@@ -74,6 +90,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="folderId">The ID of the Folder to delete.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="folderId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the folder with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to delete this folder.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task DeleteFolderAsync(
             string folderId,
             CancellationToken cancellationToken = default);
@@ -86,6 +106,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="createFolderFromTemplateRequest">Details for creating the Folder from a template.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The created <see cref="Folder"/>. Note: API might return only an ID if 'return_immediately' option is used.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="spaceId"/>, <paramref name="templateId"/>, or <paramref name="createFolderFromTemplateRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the space or template with the specified IDs are not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to perform this action.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Folder> CreateFolderFromTemplateAsync(
             string spaceId,
             string templateId,

--- a/src/ClickUp.Api.Client.Abstractions/Services/IGoalsService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/IGoalsService.cs
@@ -32,6 +32,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="includeCompleted">Optional. Whether to include completed Goals.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A <see cref="GetGoalsResponse"/> object containing lists of goals and goal folders.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the workspace with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access goals in this workspace.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<GetGoalsResponse> GetGoalsAsync(
             string workspaceId,
             bool? includeCompleted = null,
@@ -44,6 +48,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="createGoalRequest">Details of the Goal to create.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The created <see cref="Goal"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="createGoalRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the workspace with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to create goals in this workspace.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Goal> CreateGoalAsync(
             string workspaceId,
             CreateGoalRequest createGoalRequest,
@@ -55,6 +63,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="goalId">The UUID of the Goal.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Details of the <see cref="Goal"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="goalId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the goal with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access this goal.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Goal> GetGoalAsync(
             string goalId,
             CancellationToken cancellationToken = default);
@@ -66,6 +78,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="updateGoalRequest">Details for updating the Goal.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The updated <see cref="Goal"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="goalId"/> or <paramref name="updateGoalRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the goal with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to update this goal.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Goal> UpdateGoalAsync(
             string goalId,
             UpdateGoalRequest updateGoalRequest,
@@ -77,6 +93,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="goalId">The UUID of the Goal to delete.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="goalId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the goal with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to delete this goal.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task DeleteGoalAsync(
             string goalId,
             CancellationToken cancellationToken = default);
@@ -88,6 +108,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="createKeyResultRequest">Details of the Key Result to create.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The created <see cref="KeyResult"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="goalId"/> or <paramref name="createKeyResultRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the goal with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to add key results to this goal.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<KeyResult> CreateKeyResultAsync(
             string goalId,
             CreateKeyResultRequest createKeyResultRequest,
@@ -100,6 +124,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="editKeyResultRequest">Details for editing the Key Result.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The updated <see cref="KeyResult"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="keyResultId"/> or <paramref name="editKeyResultRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the key result with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to edit this key result.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<KeyResult> EditKeyResultAsync( // Method name was EditKeyResult in original
             string keyResultId,
             EditKeyResultRequest editKeyResultRequest,
@@ -111,6 +139,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="keyResultId">The UUID of the Key Result to delete.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="keyResultId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the key result with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to delete this key result.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task DeleteKeyResultAsync(
             string keyResultId,
             CancellationToken cancellationToken = default);

--- a/src/ClickUp.Api.Client.Abstractions/Services/IGuestsService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/IGuestsService.cs
@@ -28,6 +28,11 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="inviteGuestRequest">Details for inviting the guest.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains details of the invited guest, typically including the user/guest object and their role via <see cref="InviteGuestToWorkspaceResponse"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="inviteGuestRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the workspace with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiValidationException">Thrown if the invitation request is invalid (e.g., invalid email or permissions).</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to invite guests to this workspace.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<InviteGuestToWorkspaceResponse> InviteGuestToWorkspaceAsync(
             string workspaceId,
             InviteGuestToWorkspaceRequest inviteGuestRequest,
@@ -40,6 +45,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="guestId">The ID of the guest.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="GetGuestResponse"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="guestId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the workspace or guest with the specified IDs are not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access this guest's information.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<GetGuestResponse> GetGuestAsync(
             string workspaceId,
             string guestId,
@@ -53,6 +62,11 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="updateGuestRequest">Details for editing the guest's permissions or properties using <see cref="EditGuestOnWorkspaceRequest"/>.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the updated <see cref="Guest"/> details.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/>, <paramref name="guestId"/>, or <paramref name="updateGuestRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the workspace or guest with the specified IDs are not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiValidationException">Thrown if the update request is invalid.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to edit this guest.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Guest> EditGuestOnWorkspaceAsync(
             string workspaceId,
             string guestId,
@@ -67,6 +81,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
         /// <remarks>Original note mentioned API returns a 'team' object. Returning CuTask for simplicity unless team DTO is essential for client.</remarks>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="guestId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the workspace or guest with the specified IDs are not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to remove this guest from the workspace.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task RemoveGuestFromWorkspaceAsync(
             string workspaceId,
             string guestId,
@@ -83,6 +101,11 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="teamId">Optional. Workspace ID (formerly team_id), required if customTaskIds is true.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains details of the <see cref="Guest"/> and their shared items.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="taskId"/>, <paramref name="guestId"/>, or <paramref name="addGuestToItemRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the task or guest with the specified IDs are not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiValidationException">Thrown if the request to add the guest is invalid (e.g., invalid permissions).</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to add this guest to the task.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Guest> AddGuestToTaskAsync(
             string taskId,
             string guestId,
@@ -102,6 +125,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="teamId">Optional. Workspace ID (formerly team_id), required if customTaskIds is true.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains details of the <see cref="Guest"/> and their remaining shared items.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="taskId"/> or <paramref name="guestId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the task or guest with the specified IDs are not found, or the guest is not associated with the task.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to remove this guest from the task.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Guest> RemoveGuestFromTaskAsync(
             string taskId,
             string guestId,
@@ -119,6 +146,11 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="includeShared">Optional. Exclude details of items shared with the guest by setting to false.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains details of the <see cref="Guest"/> and their shared items.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="listId"/>, <paramref name="guestId"/>, or <paramref name="addGuestToItemRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the list or guest with the specified IDs are not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiValidationException">Thrown if the request to add the guest is invalid.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to add this guest to the list.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Guest> AddGuestToListAsync(
             string listId,
             string guestId,
@@ -134,6 +166,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="includeShared">Optional. Exclude details of items shared with the guest by setting to false.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains details of the <see cref="Guest"/> and their remaining shared items.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="listId"/> or <paramref name="guestId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the list or guest with the specified IDs are not found, or the guest is not associated with the list.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to remove this guest from the list.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Guest> RemoveGuestFromListAsync(
             string listId,
             string guestId,
@@ -149,6 +185,11 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="includeShared">Optional. Exclude details of items shared with the guest by setting to false.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains details of the <see cref="Guest"/> and their shared items.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="folderId"/>, <paramref name="guestId"/>, or <paramref name="addGuestToItemRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the folder or guest with the specified IDs are not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiValidationException">Thrown if the request to add the guest is invalid.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to add this guest to the folder.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Guest> AddGuestToFolderAsync(
             string folderId,
             string guestId,
@@ -164,6 +205,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="includeShared">Optional. Exclude details of items shared with the guest by setting to false.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains details of the <see cref="Guest"/> and their remaining shared items.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="folderId"/> or <paramref name="guestId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the folder or guest with the specified IDs are not found, or the guest is not associated with the folder.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to remove this guest from the folder.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Guest> RemoveGuestFromFolderAsync(
             string folderId,
             string guestId,

--- a/src/ClickUp.Api.Client.Abstractions/Services/IListsService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/IListsService.cs
@@ -34,6 +34,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="archived">Optional. Whether to include archived Lists.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A list of <see cref="ClickUpList"/> objects in the Folder.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="folderId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the folder with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access lists in this folder.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<IEnumerable<ClickUpList>> GetListsInFolderAsync(
             string folderId,
             bool? archived = null,
@@ -46,6 +50,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="createListRequest">Details of the List to create.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The created <see cref="ClickUpList"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="folderId"/> or <paramref name="createListRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the folder with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to create lists in this folder.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<ClickUpList> CreateListInFolderAsync(
             string folderId,
             CreateListRequest createListRequest,
@@ -58,6 +66,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="archived">Optional. Whether to include archived Lists.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A list of folderless <see cref="ClickUpList"/> objects in the Space.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="spaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the space with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access folderless lists in this space.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<IEnumerable<ClickUpList>> GetFolderlessListsAsync(
             string spaceId,
             bool? archived = null,
@@ -70,6 +82,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="createListRequest">Details of the List to create.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The created <see cref="ClickUpList"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="spaceId"/> or <paramref name="createListRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the space with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to create folderless lists in this space.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<ClickUpList> CreateFolderlessListAsync(
             string spaceId,
             CreateListRequest createListRequest,
@@ -81,6 +97,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="listId">The ID of the List.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Details of the <see cref="ClickUpList"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="listId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the list with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access this list.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<ClickUpList> GetListAsync(
             string listId,
             CancellationToken cancellationToken = default);
@@ -92,6 +112,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="updateListRequest">Details for updating the List.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The updated <see cref="ClickUpList"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="listId"/> or <paramref name="updateListRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the list with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to update this list.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<ClickUpList> UpdateListAsync(
             string listId,
             UpdateListRequest updateListRequest,
@@ -103,6 +127,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="listId">The ID of the List to delete.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="listId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the list with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to delete this list.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task DeleteListAsync(
             string listId,
             CancellationToken cancellationToken = default);
@@ -114,6 +142,11 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="taskId">The ID of the task to add.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="listId"/> or <paramref name="taskId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the list or task with the specified IDs are not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiValidationException">Thrown if the 'Tasks in Multiple Lists' ClickApp is not enabled or other validation fails.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to perform this action.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task AddTaskToListAsync(
             string listId,
             string taskId,
@@ -126,6 +159,11 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="taskId">The ID of the task to remove.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="listId"/> or <paramref name="taskId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the list or task with the specified IDs are not found, or the task is not in the list.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiValidationException">Thrown if the 'Tasks in Multiple Lists' ClickApp is not enabled or other validation fails.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to perform this action.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task RemoveTaskFromListAsync(
             string listId,
             string taskId,
@@ -139,6 +177,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="createListFromTemplateRequest">Details for creating the List from a template (e.g., name).</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The created <see cref="ClickUpList"/>. Note: API might return only an ID if 'return_immediately' option is used.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="folderId"/>, <paramref name="templateId"/>, or <paramref name="createListFromTemplateRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the folder or template with the specified IDs are not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to perform this action.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<ClickUpList> CreateListFromTemplateInFolderAsync(
             string folderId,
             string templateId,
@@ -153,6 +195,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="createListFromTemplateRequest">Details for creating the List from a template (e.g., name).</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The created <see cref="ClickUpList"/>. Note: API might return only an ID if 'return_immediately' option is used.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="spaceId"/>, <paramref name="templateId"/>, or <paramref name="createListFromTemplateRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the space or template with the specified IDs are not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to perform this action.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<ClickUpList> CreateListFromTemplateInSpaceAsync(
             string spaceId,
             string templateId,
@@ -166,6 +212,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="archived">Optional. Whether to include archived Lists.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An asynchronous stream of folderless lists.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="spaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the space with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access folderless lists in this space.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons during pagination.</exception>
         IAsyncEnumerable<ClickUpList> GetFolderlessListsAsyncEnumerableAsync(
             string spaceId,
             bool? archived = null,

--- a/src/ClickUp.Api.Client.Abstractions/Services/IMembersService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/IMembersService.cs
@@ -24,6 +24,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="taskId">The ID of the task.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A list of <see cref="ClickUp.Api.Client.Models.ResponseModels.Members.Member"/> objects associated with the task.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="taskId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the task with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access members for this task.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<IEnumerable<ClickUp.Api.Client.Models.ResponseModels.Members.Member>> GetTaskMembersAsync(
             string taskId,
             CancellationToken cancellationToken = default);
@@ -34,6 +38,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="listId">The ID of the List.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A list of <see cref="ClickUp.Api.Client.Models.ResponseModels.Members.Member"/> objects associated with the List.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="listId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the list with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access members for this list.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<IEnumerable<ClickUp.Api.Client.Models.ResponseModels.Members.Member>> GetListMembersAsync(
             string listId,
             CancellationToken cancellationToken = default);

--- a/src/ClickUp.Api.Client.Abstractions/Services/IRolesService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/IRolesService.cs
@@ -26,6 +26,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An enumerable of <see cref="CustomRole"/> objects for the Workspace.</returns>
         /// <remarks>The ClickUp API returns roles in a {"custom_roles": []} structure. This method should ideally return a wrapper response object if additional details like total count are needed.</remarks>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the workspace with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access custom roles for this workspace.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<IEnumerable<CustomRole>> GetCustomRolesAsync(
             string workspaceId,
             bool? includeMembers = null,

--- a/src/ClickUp.Api.Client.Abstractions/Services/ISharedHierarchyService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/ISharedHierarchyService.cs
@@ -20,6 +20,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="workspaceId">The ID of the Workspace (Team).</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A <see cref="SharedHierarchyResponse"/> object containing lists of shared tasks, lists, and folders.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the workspace with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access the shared hierarchy for this workspace.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<SharedHierarchyResponse> GetSharedHierarchyAsync(
             string workspaceId,
             CancellationToken cancellationToken = default);

--- a/src/ClickUp.Api.Client.Abstractions/Services/ISpacesService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/ISpacesService.cs
@@ -28,6 +28,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="archived">Optional. Whether to include archived Spaces.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A list of <see cref="Space"/> objects in the Workspace.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the workspace with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access spaces in this workspace.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<IEnumerable<Space>> GetSpacesAsync(
             string workspaceId,
             bool? archived = null,
@@ -40,6 +44,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="createSpaceRequest">Details of the Space to create.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The created <see cref="Space"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="createSpaceRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the workspace with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to create spaces in this workspace.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Space> CreateSpaceAsync(
             string workspaceId,
             CreateSpaceRequest createSpaceRequest,
@@ -51,6 +59,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="spaceId">The ID of the Space.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Details of the <see cref="Space"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="spaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the space with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access this space.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Space> GetSpaceAsync(
             string spaceId,
             CancellationToken cancellationToken = default);
@@ -62,6 +74,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="updateSpaceRequest">Details for updating the Space.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The updated <see cref="Space"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="spaceId"/> or <paramref name="updateSpaceRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the space with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to update this space.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Space> UpdateSpaceAsync(
             string spaceId,
             UpdateSpaceRequest updateSpaceRequest,
@@ -73,6 +89,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="spaceId">The ID of the Space to delete.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="spaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the space with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to delete this space.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task DeleteSpaceAsync(
             string spaceId,
             CancellationToken cancellationToken = default);

--- a/src/ClickUp.Api.Client.Abstractions/Services/ITagsService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/ITagsService.cs
@@ -28,6 +28,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="spaceId">The ID of the Space.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A list of <see cref="Tag"/> objects in the Space.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="spaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the space with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access tags in this space.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<IEnumerable<Tag>> GetSpaceTagsAsync(
             string spaceId,
             CancellationToken cancellationToken = default);
@@ -39,6 +43,11 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="modifyTagRequest">Details of the Tag to create.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="spaceId"/> or <paramref name="modifyTagRequest"/> is null, or if tag name in request is null/empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the space with the specified ID is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiValidationException">Thrown if a tag with the same name already exists in the space.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to create tags in this space.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task CreateSpaceTagAsync(
             string spaceId,
             ModifyTagRequest modifyTagRequest,
@@ -52,6 +61,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="modifyTagRequest">Details for updating the Tag (e.g., new name, colors).</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The updated <see cref="Tag"/> details.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="spaceId"/>, <paramref name="tagName"/>, or <paramref name="modifyTagRequest"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the space or the tag with the specified name is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to edit tags in this space.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         Task<Tag> EditSpaceTagAsync(
             string spaceId,
             string tagName,
@@ -65,6 +78,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="tagName">The name of the Tag to delete.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="spaceId"/> or <paramref name="tagName"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the space or the tag with the specified name is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to delete tags in this space.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task DeleteSpaceTagAsync(
             string spaceId,
             string tagName,
@@ -79,6 +96,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="teamId">Optional. Workspace ID (formerly team_id), required if customTaskIds is true.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="taskId"/> or <paramref name="tagName"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the task or the tag (in the task's space) with the specified ID/name is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to add tags to this task.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task AddTagToTaskAsync(
             string taskId,
             string tagName,
@@ -95,6 +116,10 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="teamId">Optional. Workspace ID (formerly team_id), required if customTaskIds is true.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="taskId"/> or <paramref name="tagName"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the task or the tag (on the task) with the specified ID/name is not found.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to remove tags from this task.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
         System.Threading.Tasks.Task RemoveTagFromTaskAsync(
             string taskId,
             string tagName,


### PR DESCRIPTION
Completed adding XML <exception> tags to the following service interfaces in `src/ClickUp.Api.Client.Abstractions/Services/`:

- IAttachmentsService.cs
- IAuthorizationService.cs
- IChatService.cs
- ICommentService.cs
- ICustomFieldsService.cs
- IDocsService.cs
- IFoldersService.cs
- IGoalsService.cs
- IGuestsService.cs
- IListsService.cs
- IMembersService.cs
- IRolesService.cs
- ISharedHierarchyService.cs
- ISpacesService.cs
- ITagsService.cs

This is part of the plan to improve overall SDK documentation and ensure all public API abstractions are well-documented for consumers and for DocFX generation.