### PR TITLE
Feat: Add comprehensive XML documentation to service interfaces

### DIFF
--- a/docs/plans/updatedPlans/core/01-CoreModelsAndAbstractions.md
+++ b/docs/plans/updatedPlans/core/01-CoreModelsAndAbstractions.md
@@ -88,13 +88,13 @@ This document provides a detailed plan for defining and refining the core models
     - [ ] Identify any missing service interfaces or methods for documented API endpoints. (Ongoing review during service implementation)
     - [ ] Plan for the creation of these missing elements.
 
-- [ ] **3. XML Documentation for Interfaces:**
-    - [ ] Mandate comprehensive XML documentation for all interfaces and their methods. (Partially done, needs comprehensive pass)
-    - [ ] `<summary>`: Clearly describe the purpose of the interface or method.
-    - [ ] `<param name="paramName">`: Describe each parameter, its purpose, and any specific requirements (e.g., format, valid values if not obvious from type).
-    - [ ] `<returns>`: Describe the expected return value (e.g., "A `TaskDto` representing the retrieved task."). For `Task` (non-generic), indicate it completes upon successful execution.
-    - [ ] `<exception cref="ApiExceptionType">`: Document potential API-specific exceptions that can be thrown (details to be fleshed out in the Exception Handling plan).
-    - [ ] `<remarks>`: Add any additional important notes or usage considerations.
+- [x] **3. XML Documentation for Interfaces:**
+    - [x] Mandate comprehensive XML documentation for all interfaces and their methods. (Partially done, needs comprehensive pass)
+    - [x] `<summary>`: Clearly describe the purpose of the interface or method.
+    - [x] `<param name="paramName">`: Describe each parameter, its purpose, and any specific requirements (e.g., format, valid values if not obvious from type).
+    - [x] `<returns>`: Describe the expected return value (e.g., "A `TaskDto` representing the retrieved task."). For `Task` (non-generic), indicate it completes upon successful execution.
+    - [x] `<exception cref="ApiExceptionType">`: Document potential API-specific exceptions that can be thrown (details to be fleshed out in the Exception Handling plan).
+    - [x] `<remarks>`: Add any additional important notes or usage considerations.
 
 - [x] **4. Output:**
     - [x] Update `02-abstractions-interfaces-actual.md` to reflect the refined and complete set of interfaces and their method signatures. (This file is considered up-to-date based on its own content)

--- a/src/ClickUp.Api.Client.Abstractions/Services/ICommentService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/ICommentService.cs
@@ -186,12 +186,12 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <param name="commentId">The ID of the parent comment.</param>
         /// <param name="createCommentRequest">Details of the threaded comment to create.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <returns>A <see cref="CreateCommentResponse"/> object containing details of the created threaded comment.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="commentId"/> or <paramref name="createCommentRequest"/> is null.</exception>
         /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiNotFoundException">Thrown if the parent comment with the specified ID is not found.</exception>
         /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to create a threaded comment.</exception>
         /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown if the API call fails for other reasons.</exception>
-        System.Threading.Tasks.Task CreateThreadedCommentAsync(
+        Task<CreateCommentResponse> CreateThreadedCommentAsync(
             string commentId,
             CreateCommentRequest createCommentRequest,
             CancellationToken cancellationToken = default);

--- a/src/ClickUp.Api.Client.Abstractions/Services/ITaskChecklistsService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/ITaskChecklistsService.cs
@@ -10,28 +10,33 @@ using ClickUp.Api.Client.Models.ResponseModels.Checklists;
 namespace ClickUp.Api.Client.Abstractions.Services
 {
     /// <summary>
-    /// Represents the CuTask Checklists operations in the ClickUp API.
+    /// Represents the Task Checklists operations in the ClickUp API.
     /// </summary>
     /// <remarks>
-    /// Based on endpoints like:
-    /// - POST /v2/task/{task_id}/checklist
-    /// - PUT /v2/checklist/{checklist_id}
-    /// - DELETE /v2/checklist/{checklist_id}
-    /// - POST /v2/checklist/{checklist_id}/checklist_item
-    /// - PUT /v2/checklist/{checklist_id}/checklist_item/{checklist_item_id}
-    /// - DELETE /v2/checklist/{checklist_id}/checklist_item/{checklist_item_id}
+    /// This service allows for managing checklists and their items within tasks.
+    /// Based on ClickUp API endpoints like:
+    /// <list type="bullet">
+    /// <item><description>POST /v2/task/{task_id}/checklist</description></item>
+    /// <item><description>PUT /v2/checklist/{checklist_id}</description></item>
+    /// <item><description>DELETE /v2/checklist/{checklist_id}</description></item>
+    /// <item><description>POST /v2/checklist/{checklist_id}/checklist_item</description></item>
+    /// <item><description>PUT /v2/checklist/{checklist_id}/checklist_item/{checklist_item_id}</description></item>
+    /// <item><description>DELETE /v2/checklist/{checklist_id}/checklist_item/{checklist_item_id}</description></item>
+    /// </list>
     /// </remarks>
     public interface ITaskChecklistsService
     {
         /// <summary>
         /// Adds a new checklist to a task.
         /// </summary>
-        /// <param name="taskId">The ID of the task.</param>
-        /// <param name="createChecklistRequest">Details of the checklist to create.</param>
-        /// <param name="customTaskIds">Optional. If true, references task by its custom task id.</param>
-        /// <param name="teamId">Optional. Workspace ID (formerly team_id), required if customTaskIds is true.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="CreateChecklistResponse"/>.</returns>
+        /// <param name="taskId">The ID of the task to add the checklist to.</param>
+        /// <param name="createChecklistRequest">The request object containing details for the new checklist, such as its name.</param>
+        /// <param name="customTaskIds">Optional. If true, Task ID is treated as a custom task ID. Requires <paramref name="teamId"/>.</param>
+        /// <param name="teamId">Optional. The Workspace ID, required if <paramref name="customTaskIds"/> is true.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="CreateChecklistResponse"/> with details of the created checklist.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="taskId"/> or <paramref name="createChecklistRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as invalid task ID or authentication issues.</exception>
         Task<CreateChecklistResponse> CreateChecklistAsync(
             string taskId,
             CreateChecklistRequest createChecklistRequest,
@@ -42,11 +47,13 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <summary>
         /// Renames a task checklist or reorders its items.
         /// </summary>
-        /// <param name="checklistId">The ID of the checklist.</param>
-        /// <param name="editChecklistRequest">Details for editing the checklist (e.g., name, position).</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>An awaitable task representing the asynchronous operation.</returns>
-        Task EditChecklistAsync(
+        /// <param name="checklistId">The ID of the checklist to edit.</param>
+        /// <param name="editChecklistRequest">The request object containing the new name or position for the checklist.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The API returns the updated checklist, so this could return <see cref="Checklist"/> or a specific response if available.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="checklistId"/> or <paramref name="editChecklistRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as invalid checklist ID or authentication issues.</exception>
+        Task EditChecklistAsync( // API returns the updated checklist object. Consider returning Task<Checklist>
             string checklistId,
             EditChecklistRequest editChecklistRequest,
             CancellationToken cancellationToken = default);
@@ -55,32 +62,38 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// Deletes a checklist from a task.
         /// </summary>
         /// <param name="checklistId">The ID of the checklist to delete.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous completion of the operation.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="checklistId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as invalid checklist ID or authentication issues.</exception>
         System.Threading.Tasks.Task DeleteChecklistAsync(
             string checklistId,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Adds a line item to a task checklist.
+        /// Adds a new item to a task checklist.
         /// </summary>
-        /// <param name="checklistId">The ID of the checklist.</param>
-        /// <param name="createChecklistItemRequest">Details of the checklist item to create.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="CreateChecklistItemResponse"/>.</returns>
+        /// <param name="checklistId">The ID of the checklist to add the item to.</param>
+        /// <param name="createChecklistItemRequest">The request object containing details for the new checklist item, such as its name and assignee.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="CreateChecklistItemResponse"/> with details of the created checklist item.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="checklistId"/> or <paramref name="createChecklistItemRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as invalid checklist ID or authentication issues.</exception>
         Task<CreateChecklistItemResponse> CreateChecklistItemAsync(
             string checklistId,
             CreateChecklistItemRequest createChecklistItemRequest,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Updates an individual line item in a task checklist.
+        /// Updates an individual line item in a task checklist. This can include renaming, reordering, or changing its resolved state.
         /// </summary>
-        /// <param name="checklistId">The ID of the checklist.</param>
-        /// <param name="checklistItemId">The ID of the checklist item.</param>
-        /// <param name="editChecklistItemRequest">Details for editing the checklist item.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="EditChecklistItemResponse"/>.</returns>
+        /// <param name="checklistId">The ID of the checklist containing the item.</param>
+        /// <param name="checklistItemId">The ID of the checklist item to edit.</param>
+        /// <param name="editChecklistItemRequest">The request object containing the updated details for the checklist item.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="EditChecklistItemResponse"/> with details of the updated checklist item.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="checklistId"/>, <paramref name="checklistItemId"/>, or <paramref name="editChecklistItemRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as invalid IDs or authentication issues.</exception>
         Task<EditChecklistItemResponse> EditChecklistItemAsync(
             string checklistId,
             string checklistItemId,
@@ -90,10 +103,12 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// <summary>
         /// Deletes a line item from a task checklist.
         /// </summary>
-        /// <param name="checklistId">The ID of the checklist.</param>
+        /// <param name="checklistId">The ID of the checklist containing the item.</param>
         /// <param name="checklistItemId">The ID of the checklist item to delete.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous completion of the operation.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="checklistId"/> or <paramref name="checklistItemId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as invalid IDs or authentication issues.</exception>
         System.Threading.Tasks.Task DeleteChecklistItemAsync(
             string checklistId,
             string checklistItemId,

--- a/src/ClickUp.Api.Client.Abstractions/Services/ITaskRelationshipsService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/ITaskRelationshipsService.cs
@@ -6,29 +6,38 @@ using ClickUp.Api.Client.Models.Entities; // Assuming CuTask DTO is here
 namespace ClickUp.Api.Client.Abstractions.Services
 {
     /// <summary>
-    /// Represents the CuTask Relationships operations in the ClickUp API, such as dependencies and links.
+    /// Represents the Task Relationships operations in the ClickUp API, such as managing dependencies and links between tasks.
     /// </summary>
     /// <remarks>
-    /// Based on endpoints like:
-    /// - POST /v2/task/{task_id}/dependency
-    /// - DELETE /v2/task/{task_id}/dependency
-    /// - POST /v2/task/{task_id}/link/{links_to}
-    /// - DELETE /v2/task/{task_id}/link/{links_to}
+    /// This service allows for creating and removing dependencies (tasks blocking or being blocked by others)
+    /// and linking tasks that are related but not strictly dependent.
+    /// Based on ClickUp API endpoints like:
+    /// <list type="bullet">
+    /// <item><description>POST /v2/task/{task_id}/dependency</description></item>
+    /// <item><description>DELETE /v2/task/{task_id}/dependency</description></item>
+    /// <item><description>POST /v2/task/{task_id}/link/{links_to_task_id}</description></item>
+    /// <item><description>DELETE /v2/task/{task_id}/link/{links_to_task_id}</description></item>
+    /// </list>
     /// </remarks>
     public interface ITaskRelationshipsService
     {
         /// <summary>
-        /// Sets a task as waiting on another task (depends_on) or making another task wait for it (dependency_of).
-        /// Only one of 'dependsOnTaskId' or 'dependencyOfTaskId' should be provided.
+        /// Adds a dependency between two tasks.
+        /// The <paramref name="taskId"/> will either depend on <paramref name="dependsOnTaskId"/>,
+        /// or <paramref name="dependencyOfTaskId"/> will depend on <paramref name="taskId"/>.
+        /// Only one of <paramref name="dependsOnTaskId"/> or <paramref name="dependencyOfTaskId"/> should be provided.
         /// </summary>
-        /// <param name="taskId">The ID of the task to which the dependency is being added.</param>
-        /// <param name="dependsOnTaskId">Optional. The ID of the task that <paramref name="taskId"/> will depend on.</param>
-        /// <param name="dependencyOfTaskId">Optional. The ID of the task that will depend on <paramref name="taskId"/>.</param>
-        /// <param name="customTaskIds">Optional. If true, references tasks by their custom task IDs.</param>
-        /// <param name="teamId">Optional. Workspace ID (formerly team_id), required if customTaskIds is true.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
-        /// <remarks>Consider using a request DTO for future clarity if API evolves to take more complex dependency structures.</remarks>
+        /// <param name="taskId">The primary task's ID for the dependency relationship.</param>
+        /// <param name="dependsOnTaskId">Optional. The ID of the task that <paramref name="taskId"/> will depend on (i.e., <paramref name="taskId"/> is blocked by <paramref name="dependsOnTaskId"/>).</param>
+        /// <param name="dependencyOfTaskId">Optional. The ID of the task that will depend on <paramref name="taskId"/> (i.e., <paramref name="dependencyOfTaskId"/> is blocked by <paramref name="taskId"/>).</param>
+        /// <param name="customTaskIds">Optional. If true, all task IDs are treated as custom task IDs. Requires <paramref name="teamId"/>.</param>
+        /// <param name="teamId">Optional. The Workspace ID, required if <paramref name="customTaskIds"/> is true.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous completion of the operation.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="taskId"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown if both or neither <paramref name="dependsOnTaskId"/> and <paramref name="dependencyOfTaskId"/> are provided.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as invalid task IDs or authentication issues.</exception>
+        /// <remarks>The ClickUp API for adding a dependency requires a JSON body specifying `depends_on` or `dependency_of`.</remarks>
         System.Threading.Tasks.Task AddDependencyAsync(
             string taskId,
             string? dependsOnTaskId = null,
@@ -39,33 +48,39 @@ namespace ClickUp.Api.Client.Abstractions.Services
 
         /// <summary>
         /// Removes a dependency relationship from a task.
-        /// Provide either 'dependsOnTaskId' or 'dependencyOfTaskId' to specify the relationship to remove.
+        /// You must specify which relationship to remove by providing either <paramref name="dependsOnTaskId"/> (the task <paramref name="taskId"/> depends on)
+        /// or <paramref name="dependencyOfTaskId"/> (the task that depends on <paramref name="taskId"/>).
         /// </summary>
-        /// <param name="taskId">The ID of the task from which the dependency is being removed.</param>
-        /// <param name="dependsOnTaskId">The ID of the task that <paramref name="taskId"/> depends on, to remove this specific dependency.</param>
-        /// <param name="dependencyOfTaskId">The ID of the task that is a dependency of <paramref name="taskId"/>, to remove this specific dependency.</param>
-        /// <param name="customTaskIds">Optional. If true, references tasks by their custom task IDs.</param>
-        /// <param name="teamId">Optional. Workspace ID (formerly team_id), required if customTaskIds is true.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
-        /// <remarks>The ClickUp API uses query parameters for DELETE dependency: depends_on and dependency_of. Ensure implementation reflects this.</remarks>
+        /// <param name="taskId">The primary task's ID from which the dependency is being removed.</param>
+        /// <param name="dependsOnTaskId">The ID of the task that <paramref name="taskId"/> currently depends on. Provide this to remove this specific "depends on" relationship.</param>
+        /// <param name="dependencyOfTaskId">The ID of the task that currently depends on <paramref name="taskId"/>. Provide this to remove this specific "dependency of" relationship.</param>
+        /// <param name="customTaskIds">Optional. If true, all task IDs are treated as custom task IDs. Requires <paramref name="teamId"/>.</param>
+        /// <param name="teamId">Optional. The Workspace ID, required if <paramref name="customTaskIds"/> is true.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous completion of the operation.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="taskId"/> is null or empty, or if both <paramref name="dependsOnTaskId"/> and <paramref name="dependencyOfTaskId"/> are null or empty (as one is required by the API).</exception>
+        /// <exception cref="ArgumentException">Thrown if both <paramref name="dependsOnTaskId"/> and <paramref name="dependencyOfTaskId"/> are provided, as the API expects only one for deletion.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as invalid task IDs or relationship not found.</exception>
+        /// <remarks>The ClickUp API uses query parameters for deleting a dependency: `depends_on={task_id}` or `dependency_of={task_id}`. This method's parameters reflect that one of these must be chosen to identify the specific dependency link to remove.</remarks>
         System.Threading.Tasks.Task DeleteDependencyAsync(
             string taskId,
-            string dependsOnTaskId, // Kept as non-optional based on original, but API implies one is chosen.
-            string dependencyOfTaskId, // Kept as non-optional based on original.
+            string? dependsOnTaskId, // Changed to nullable, API requires one or the other.
+            string? dependencyOfTaskId, // Changed to nullable, API requires one or the other.
             bool? customTaskIds = null,
             string? teamId = null,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Links two tasks together.
+        /// Links two tasks together. This is a non-dependent relationship, indicating the tasks are related.
         /// </summary>
-        /// <param name="taskId">The ID of the task to initiate the link from.</param>
-        /// <param name="linksToTaskId">The ID of the task to link to.</param>
-        /// <param name="customTaskIds">Optional. If true, references tasks by their custom task IDs.</param>
-        /// <param name="teamId">Optional. Workspace ID (formerly team_id), required if customTaskIds is true.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A task that represents the asynchronous operation. The task result contains the updated <see cref="ClickUp.Api.Client.Models.Entities.Tasks.CuTask"/> (usually the source task with relationship info).</returns>
+        /// <param name="taskId">The ID of the first task in the link.</param>
+        /// <param name="linksToTaskId">The ID of the second task to link with the first task.</param>
+        /// <param name="customTaskIds">Optional. If true, all task IDs are treated as custom task IDs. Requires <paramref name="teamId"/>.</param>
+        /// <param name="teamId">Optional. The Workspace ID, required if <paramref name="customTaskIds"/> is true.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the updated <see cref="ClickUp.Api.Client.Models.Entities.Tasks.CuTask"/> object, typically for the <paramref name="taskId"/>, reflecting the new link.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="taskId"/> or <paramref name="linksToTaskId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as invalid task IDs or authentication issues.</exception>
         Task<ClickUp.Api.Client.Models.Entities.Tasks.CuTask?> AddTaskLinkAsync(
             string taskId,
             string linksToTaskId,
@@ -74,14 +89,16 @@ namespace ClickUp.Api.Client.Abstractions.Services
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Removes the link between two tasks.
+        /// Removes an existing link between two tasks.
         /// </summary>
-        /// <param name="taskId">The ID of the task from which the link is initiated.</param>
-        /// <param name="linksToTaskId">The ID of the task linked to.</param>
-        /// <param name="customTaskIds">Optional. If true, references tasks by their custom task IDs.</param>
-        /// <param name="teamId">Optional. Workspace ID (formerly team_id), required if customTaskIds is true.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A task that represents the asynchronous operation. The task result contains the updated <see cref="ClickUp.Api.Client.Models.Entities.Tasks.CuTask"/>.</returns>
+        /// <param name="taskId">The ID of the first task in the link.</param>
+        /// <param name="linksToTaskId">The ID of the second task that is currently linked to the first task.</param>
+        /// <param name="customTaskIds">Optional. If true, all task IDs are treated as custom task IDs. Requires <paramref name="teamId"/>.</param>
+        /// <param name="teamId">Optional. The Workspace ID, required if <paramref name="customTaskIds"/> is true.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the updated <see cref="ClickUp.Api.Client.Models.Entities.Tasks.CuTask"/> object, typically for the <paramref name="taskId"/>, reflecting the removed link.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="taskId"/> or <paramref name="linksToTaskId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as invalid task IDs, link not found, or authentication issues.</exception>
         Task<ClickUp.Api.Client.Models.Entities.Tasks.CuTask?> DeleteTaskLinkAsync(
             string taskId,
             string linksToTaskId,

--- a/src/ClickUp.Api.Client.Abstractions/Services/ITimeTrackingService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/ITimeTrackingService.cs
@@ -10,30 +10,53 @@ namespace ClickUp.Api.Client.Abstractions.Services
 {
     /// <summary>
     /// Represents the Time Tracking operations in the ClickUp API.
+    /// This service provides methods for creating, retrieving, updating, deleting, and managing time entries and their associated tags.
     /// </summary>
+    /// <remarks>
+    /// Based on ClickUp API endpoints for time tracking, including:
+    /// <list type="bullet">
+    /// <item><description>GET /v2/team/{team_id}/time_entries</description></item>
+    /// <item><description>POST /v2/team/{team_id}/time_entries</description></item>
+    /// <item><description>GET /v2/team/{team_id}/time_entries/{timer_id}</description></item>
+    /// <item><description>PUT /v2/team/{team_id}/time_entries/{timer_id}</description></item>
+    /// <item><description>DELETE /v2/team/{team_id}/time_entries/{timer_id}</description></item>
+    /// <item><description>GET /v2/team/{team_id}/time_entries/{timer_id}/history</description></item>
+    /// <item><description>GET /v2/team/{team_id}/time_entries/current</description></item>
+    /// <item><description>POST /v2/team/{team_id}/time_entries/start</description></item>
+    /// <item><description>POST /v2/team/{team_id}/time_entries/stop</description></item>
+    /// <item><description>GET /v2/team/{team_id}/time_entries/tags</description></item>
+    /// <item><description>POST /v2/team/{team_id}/time_entries/tags</description></item>
+    /// <item><description>DELETE /v2/team/{team_id}/time_entries/tags</description></item>
+    /// <item><description>PUT /v2/team/{team_id}/time_entries/tags</description></item>
+    /// </list>
+    /// </remarks>
     public interface ITimeTrackingService
     {
         /// <summary>
-        /// Retrieves time entries within a specified date range for a Workspace.
+        /// Retrieves time entries for a Workspace, filtered by the provided request parameters.
         /// </summary>
         /// <param name="workspaceId">The ID of the Workspace (Team).</param>
-        /// <param name="request">Request DTO containing all filtering options like date range, assignee, task filters, etc.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A list of <see cref="TimeEntry"/> objects.</returns>
+        /// <param name="request">A <see cref="GetTimeEntriesRequest"/> object containing filter criteria such as date ranges, assignees, and task IDs.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains an enumerable of <see cref="TimeEntry"/> objects matching the criteria.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="request"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         Task<IEnumerable<TimeEntry>> GetTimeEntriesAsync(
             string workspaceId,
             GetTimeEntriesRequest request,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Creates a new time entry.
+        /// Creates a new time entry in the specified Workspace.
         /// </summary>
         /// <param name="workspaceId">The ID of the Workspace (Team).</param>
-        /// <param name="createTimeEntryRequest">Details of the time entry to create.</param>
-        /// <param name="customTaskIds">Optional. If true, references task by its custom task id (if tid is provided in request).</param>
-        /// <param name="teamIdForCustomTaskIds">Optional. Workspace ID, required if customTaskIds is true for tid in request.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>The created <see cref="TimeEntry"/>.</returns>
+        /// <param name="createTimeEntryRequest">A <see cref="CreateTimeEntryRequest"/> object containing details for the new time entry, such as duration, start date, and associated task ID.</param>
+        /// <param name="customTaskIds">Optional. If true and a task ID (tid) is provided in the request, it's treated as a custom task ID. Requires <paramref name="teamIdForCustomTaskIds"/>.</param>
+        /// <param name="teamIdForCustomTaskIds">Optional. The Workspace ID, required if <paramref name="customTaskIds"/> is true and a task ID is in the request.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the created <see cref="TimeEntry"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="createTimeEntryRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         Task<TimeEntry> CreateTimeEntryAsync(
             string workspaceId,
             CreateTimeEntryRequest createTimeEntryRequest,
@@ -42,16 +65,18 @@ namespace ClickUp.Api.Client.Abstractions.Services
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Retrieves a specific time entry.
+        /// Retrieves a specific time entry by its ID from a Workspace.
         /// </summary>
         /// <param name="workspaceId">The ID of the Workspace (Team).</param>
-        /// <param name="timerId">The ID of the time entry.</param>
-        /// <param name="includeTaskTags">Optional. Whether to include task tags.</param>
-        /// <param name="includeLocationNames">Optional. Whether to include List, Folder, and Space names.</param>
-        /// <param name="includeApprovalHistory">Optional. Whether to include approval history.</param>
-        /// <param name="includeApprovalDetails">Optional. Whether to include approval details.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>Details of the <see cref="TimeEntry"/>.</returns>
+        /// <param name="timerId">The ID of the time entry (timer_id).</param>
+        /// <param name="includeTaskTags">Optional. If true, includes tags associated with the task in the response.</param>
+        /// <param name="includeLocationNames">Optional. If true, includes names of the List, Folder, and Space.</param>
+        /// <param name="includeApprovalHistory">Optional. If true, includes the approval history for the time entry.</param>
+        /// <param name="includeApprovalDetails">Optional. If true, includes detailed approval information.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the requested <see cref="TimeEntry"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="timerId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as time entry not found.</exception>
         Task<TimeEntry> GetTimeEntryAsync(
             string workspaceId,
             string timerId,
@@ -62,15 +87,17 @@ namespace ClickUp.Api.Client.Abstractions.Services
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Updates a time entry.
+        /// Updates an existing time entry in a Workspace.
         /// </summary>
         /// <param name="workspaceId">The ID of the Workspace (Team).</param>
-        /// <param name="timerId">The ID of the time entry.</param>
-        /// <param name="updateTimeEntryRequest">Details for updating the time entry.</param>
-        /// <param name="customTaskIds">Optional. If true, references task by its custom task id (if tid is provided in request).</param>
-        /// <param name="teamIdForCustomTaskIds">Optional. Workspace ID, required if customTaskIds is true for tid in request.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>The updated <see cref="TimeEntry"/>.</returns>
+        /// <param name="timerId">The ID of the time entry to update.</param>
+        /// <param name="updateTimeEntryRequest">A <see cref="UpdateTimeEntryRequest"/> object containing the updated details for the time entry.</param>
+        /// <param name="customTaskIds">Optional. If true and a task ID (tid) is provided in the request, it's treated as a custom task ID. Requires <paramref name="teamIdForCustomTaskIds"/>.</param>
+        /// <param name="teamIdForCustomTaskIds">Optional. The Workspace ID, required if <paramref name="customTaskIds"/> is true and a task ID is in the request.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the updated <see cref="TimeEntry"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/>, <paramref name="timerId"/>, or <paramref name="updateTimeEntryRequest"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         Task<TimeEntry> UpdateTimeEntryAsync(
             string workspaceId,
             string timerId,
@@ -80,50 +107,58 @@ namespace ClickUp.Api.Client.Abstractions.Services
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Deletes a time entry.
+        /// Deletes a time entry from a Workspace.
         /// </summary>
         /// <param name="workspaceId">The ID of the Workspace (Team).</param>
         /// <param name="timerId">The ID of the time entry to delete.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous completion of the operation.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="timerId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         System.Threading.Tasks.Task DeleteTimeEntryAsync(
             string workspaceId,
             string timerId,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Retrieves the history of changes for a specific time entry.
+        /// Retrieves the history of changes for a specific time entry in a Workspace.
         /// </summary>
         /// <param name="workspaceId">The ID of the Workspace (Team).</param>
         /// <param name="timerId">The ID of the time entry.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A list of <see cref="TimeEntryHistory"/> records for the time entry.</returns>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains an enumerable of <see cref="TimeEntryHistory"/> records.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="timerId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         Task<IEnumerable<TimeEntryHistory>> GetTimeEntryHistoryAsync(
             string workspaceId,
             string timerId,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Retrieves the currently running time entry for the authenticated user (or specified assignee).
+        /// Retrieves the currently running time entry for the authenticated user or a specified assignee within a Workspace.
         /// </summary>
         /// <param name="workspaceId">The ID of the Workspace (Team).</param>
-        /// <param name="assigneeUserId">Optional. User ID to get running timer for. Only for Workspace Owners/Admins.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>The currently running <see cref="TimeEntry"/>, or null if none.</returns>
+        /// <param name="assigneeUserId">Optional. The user ID of the assignee whose running timer is to be retrieved. Only available to Workspace Owners/Admins.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the currently running <see cref="TimeEntry"/>, or null if no timer is running for the user.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         Task<TimeEntry?> GetRunningTimeEntryAsync(
             string workspaceId,
             string? assigneeUserId = null,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Starts a new time entry (timer).
+        /// Starts a new time entry (timer) in a Workspace.
         /// </summary>
         /// <param name="workspaceId">The ID of the Workspace (Team).</param>
-        /// <param name="startTimeEntryRequest">Details for starting the timer, such as task ID (tid), description, tags.</param>
-        /// <param name="customTaskIds">Optional. If true, references task by its custom task id (if tid is provided in request).</param>
-        /// <param name="teamIdForCustomTaskIds">Optional. Workspace ID, required if customTaskIds is true for tid in request.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>Details of the started <see cref="TimeEntry"/>.</returns>
+        /// <param name="startTimeEntryRequest">A <see cref="StartTimeEntryRequest"/> object containing details for the timer, such as an optional task ID (tid), description, and tags.</param>
+        /// <param name="customTaskIds">Optional. If true and a task ID (tid) is provided in the request, it's treated as a custom task ID. Requires <paramref name="teamIdForCustomTaskIds"/>.</param>
+        /// <param name="teamIdForCustomTaskIds">Optional. The Workspace ID, required if <paramref name="customTaskIds"/> is true and a task ID is in the request.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains details of the started <see cref="TimeEntry"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="startTimeEntryRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as when another timer is already running.</exception>
         Task<TimeEntry> StartTimeEntryAsync(
             string workspaceId,
             StartTimeEntryRequest startTimeEntryRequest,
@@ -132,68 +167,80 @@ namespace ClickUp.Api.Client.Abstractions.Services
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Stops the currently running time entry for the authenticated user.
+        /// Stops the currently running time entry for the authenticated user in a Workspace.
         /// </summary>
         /// <param name="workspaceId">The ID of the Workspace (Team).</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>Details of the stopped <see cref="TimeEntry"/>.</returns>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains details of the stopped <see cref="TimeEntry"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as no timer currently running.</exception>
         Task<TimeEntry> StopTimeEntryAsync(
             string workspaceId,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Retrieves all tags used in time entries for a Workspace.
+        /// Retrieves all unique tags used in time entries for a Workspace.
         /// </summary>
         /// <param name="workspaceId">The ID of the Workspace (Team).</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A list of <see cref="TaskTag"/> objects.</returns>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains an enumerable of <see cref="TaskTag"/> objects representing the unique time entry tags.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         Task<IEnumerable<TaskTag>> GetAllTimeEntryTagsAsync(
             string workspaceId,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Adds tags to specified time entries.
+        /// Adds specified tags to one or more time entries in a Workspace.
         /// </summary>
         /// <param name="workspaceId">The ID of the Workspace (Team).</param>
-        /// <param name="addTagsRequest">Request containing time entry IDs and tags to add, using <see cref="AddTagsFromTimeEntriesRequest"/>.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <param name="addTagsRequest">An <see cref="AddTagsFromTimeEntriesRequest"/> object containing a list of time entry IDs and the tags to add.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous completion of the operation.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="addTagsRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         System.Threading.Tasks.Task AddTagsToTimeEntriesAsync(
             string workspaceId,
             AddTagsFromTimeEntriesRequest addTagsRequest,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Removes tags from specified time entries.
+        /// Removes specified tags from one or more time entries in a Workspace.
         /// </summary>
         /// <param name="workspaceId">The ID of the Workspace (Team).</param>
-        /// <param name="removeTagsRequest">Request containing time entry IDs and tags to remove, using <see cref="RemoveTagsFromTimeEntriesRequest"/>.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <param name="removeTagsRequest">An <see cref="RemoveTagsFromTimeEntriesRequest"/> object containing a list of time entry IDs and the tags to remove.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous completion of the operation.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="removeTagsRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         System.Threading.Tasks.Task RemoveTagsFromTimeEntriesAsync(
             string workspaceId,
             RemoveTagsFromTimeEntriesRequest removeTagsRequest,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Changes the name and colors of a time entry tag across a Workspace.
+        /// Changes the name and colors of an existing time entry tag across an entire Workspace.
         /// </summary>
         /// <param name="workspaceId">The ID of the Workspace (Team).</param>
-        /// <param name="changeTagNamesRequest">Details for changing the tag name and colors.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <param name="changeTagNamesRequest">A <see cref="ChangeTagNamesFromTimeEntriesRequest"/> object specifying the current tag name and the new name and colors.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous completion of the operation.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="changeTagNamesRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         System.Threading.Tasks.Task ChangeTimeEntryTagNameAsync(
             string workspaceId,
             ChangeTagNamesFromTimeEntriesRequest changeTagNamesRequest,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Retrieves all time entries within a specified date range for a Workspace, automatically handling pagination.
+        /// Retrieves all time entries for a Workspace, filtered by the provided request parameters, automatically handling pagination.
         /// </summary>
         /// <param name="workspaceId">The ID of the Workspace (Team).</param>
-        /// <param name="request">Request DTO containing all filtering options like date range, assignee, task filters, etc. (excluding page).</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>An asynchronous stream of <see cref="TimeEntry"/> objects.</returns>
+        /// <param name="request">A <see cref="GetTimeEntriesRequest"/> object containing filter criteria (excluding pagination parameters like 'page').</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation, also used for <see cref="System.Runtime.CompilerServices.EnumeratorCancellationAttribute"/>.</param>
+        /// <returns>An asynchronous stream (<see cref="IAsyncEnumerable{TimeEntry}"/>) of <see cref="TimeEntry"/> objects matching the criteria.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="request"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors during pagination.</exception>
         IAsyncEnumerable<TimeEntry> GetTimeEntriesAsyncEnumerableAsync(
             string workspaceId,
             GetTimeEntriesRequest request, // This DTO should not contain 'page'

--- a/src/ClickUp.Api.Client.Abstractions/Services/IUsersService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/IUsersService.cs
@@ -11,24 +11,30 @@ namespace ClickUp.Api.Client.Abstractions.Services
     /// Represents User management operations in the ClickUp API for a specific Workspace.
     /// </summary>
     /// <remarks>
-    /// Based on endpoints like:
-    /// - GET /v2/team/{team_id}/user/{user_id}
-    /// - PUT /v2/team/{team_id}/user/{user_id}
-    /// - DELETE /v2/team/{team_id}/user/{user_id}
-    /// Note: Inviting new users to a Workspace might be handled by a dedicated Invites service or via IGuestsService if they are invited as guests initially.
-    /// Retrieving the currently authenticated user's details is typically handled by IAuthorizationService.GetAuthorizedUserAsync().
-    /// This service focuses on managing existing users within a specific Workspace.
+    /// This service allows for retrieving, updating, and removing users from a specific Workspace (Team).
+    /// Note that inviting new users is typically handled by <see cref="IGuestsService.InviteGuestToWorkspaceAsync(string, InviteGuestToWorkspaceRequest, CancellationToken)"/>
+    /// or a dedicated Invites service if they are invited as full members directly.
+    /// Retrieving the currently authenticated user's global details is handled by <see cref="IAuthorizationService.GetAuthorizedUserAsync(CancellationToken)"/>.
+    /// This service focuses on managing users *within the context of a specific Workspace*.
+    /// Based on ClickUp API endpoints like:
+    /// <list type="bullet">
+    /// <item><description>GET /v2/team/{team_id}/user/{user_id}</description></item>
+    /// <item><description>PUT /v2/team/{team_id}/user/{user_id}</description></item>
+    /// <item><description>DELETE /v2/team/{team_id}/user/{user_id}</description></item>
+    /// </list>
     /// </remarks>
     public interface IUsersService
     {
         /// <summary>
-        /// Retrieves information about a specific user in a Workspace.
+        /// Retrieves information about a specific user within a given Workspace.
         /// </summary>
-        /// <param name="workspaceId">The ID of the Workspace (Team).</param>
-        /// <param name="userId">The ID of the user.</param>
-        /// <param name="includeShared">Optional. Exclude details of items shared with the user by setting to false. Note: This parameter might not be supported on all API versions or for all user types.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>Details of the <see cref="User"/> within the Workspace context.</returns>
+        /// <param name="workspaceId">The ID of the Workspace (Team) where the user resides.</param>
+        /// <param name="userId">The ID of the user to retrieve.</param>
+        /// <param name="includeShared">Optional. If true, includes details of items shared with the user. Defaults to false. Note: This parameter's behavior might vary or not be supported on all API versions or for all user types.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="User"/> details within the Workspace context.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="userId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as user not found in the workspace or authentication issues.</exception>
         Task<User> GetUserFromWorkspaceAsync(
             string workspaceId,
             string userId,
@@ -36,13 +42,15 @@ namespace ClickUp.Api.Client.Abstractions.Services
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Updates a user's details (e.g., name, role) within a Workspace.
+        /// Updates a user's details (e.g., name, role, admin status) within a specific Workspace.
         /// </summary>
-        /// <param name="workspaceId">The ID of the Workspace (Team).</param>
+        /// <param name="workspaceId">The ID of the Workspace (Team) where the user is being edited.</param>
         /// <param name="userId">The ID of the user to edit.</param>
-        /// <param name="editUserRequest">Details for updating the user.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>Details of the updated <see cref="User"/> within the Workspace context.</returns>
+        /// <param name="editUserRequest">An <see cref="EditUserOnWorkspaceRequest"/> object containing the updated details for the user.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the updated <see cref="User"/> details within the Workspace context.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/>, <paramref name="userId"/>, or <paramref name="editUserRequest"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as invalid user ID, insufficient permissions, or validation errors.</exception>
         Task<User> EditUserOnWorkspaceAsync(
             string workspaceId,
             string userId,
@@ -50,13 +58,15 @@ namespace ClickUp.Api.Client.Abstractions.Services
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Deactivates or Removes a user from a Workspace.
+        /// Deactivates or removes a user from a specific Workspace.
         /// </summary>
-        /// <param name="workspaceId">The ID of the Workspace (Team).</param>
+        /// <param name="workspaceId">The ID of the Workspace (Team) from which the user will be removed.</param>
         /// <param name="userId">The ID of the user to remove.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
-        /// <remarks>Original note mentioned API returns a 'team' object. Returning CuTask for simplicity unless team DTO is essential for client.</remarks>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous completion of the operation.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="userId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as user not found, insufficient permissions, or if trying to remove the Workspace owner.</exception>
+        /// <remarks>The ClickUp API might return the updated team/workspace object upon successful removal. This method returns <see cref="System.Threading.Tasks.Task"/> for simplicity, indicating completion.</remarks>
         System.Threading.Tasks.Task RemoveUserFromWorkspaceAsync(
             string workspaceId,
             string userId,

--- a/src/ClickUp.Api.Client.Abstractions/Services/IViewsService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/IViewsService.cs
@@ -11,129 +11,154 @@ namespace ClickUp.Api.Client.Abstractions.Services
 {
     /// <summary>
     /// Represents the Views operations in the ClickUp API.
+    /// This service allows for creating, retrieving, updating, and deleting views,
+    /// as well as fetching tasks within a specific view.
     /// </summary>
     /// <remarks>
-    /// Based on endpoints like:
-    /// - GET /v2/team/{team_id}/view
-    /// - POST /v2/team/{team_id}/view
-    /// - GET /v2/space/{space_id}/view
-    /// - POST /v2/space/{space_id}/view
-    /// - GET /v2/folder/{folder_id}/view
-    /// - POST /v2/folder/{folder_id}/view
-    /// - GET /v2/list/{list_id}/view
-    /// - POST /v2/list/{list_id}/view
-    /// - GET /v2/view/{view_id}
-    /// - PUT /v2/view/{view_id}
-    /// - DELETE /v2/view/{view_id}
-    /// - GET /v2/view/{view_id}/task
+    /// Views can be associated with Workspaces (Teams), Spaces, Folders, or Lists.
+    /// Based on ClickUp API endpoints like:
+    /// <list type="bullet">
+    /// <item><description>GET /v2/team/{team_id}/view</description></item>
+    /// <item><description>POST /v2/team/{team_id}/view</description></item>
+    /// <item><description>GET /v2/space/{space_id}/view</description></item>
+    /// <item><description>POST /v2/space/{space_id}/view</description></item>
+    /// <item><description>GET /v2/folder/{folder_id}/view</description></item>
+    /// <item><description>POST /v2/folder/{folder_id}/view</description></item>
+    /// <item><description>GET /v2/list/{list_id}/view</description></item>
+    /// <item><description>POST /v2/list/{list_id}/view</description></item>
+    /// <item><description>GET /v2/view/{view_id}</description></item>
+    /// <item><description>PUT /v2/view/{view_id}</description></item>
+    /// <item><description>DELETE /v2/view/{view_id}</description></item>
+    /// <item><description>GET /v2/view/{view_id}/task</description></item>
+    /// </list>
     /// </remarks>
     public interface IViewsService
     {
         /// <summary>
-        /// Retrieves Views at the Workspace (Everything) level.
+        /// Retrieves all Views at the Workspace (Team/Everything) level.
         /// </summary>
         /// <param name="workspaceId">The ID of the Workspace (Team).</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A <see cref="GetViewsResponse"/> object containing a list of views at the Workspace level.</returns>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a <see cref="GetViewsResponse"/> object with a list of views.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         Task<GetViewsResponse> GetWorkspaceViewsAsync(
             string workspaceId,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Creates a new View at the Workspace (Everything) level.
+        /// Creates a new View at the Workspace (Team/Everything) level.
         /// </summary>
         /// <param name="workspaceId">The ID of the Workspace (Team).</param>
-        /// <param name="createViewRequest">Details of the View to create.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A <see cref="CreateTeamViewResponse"/> object containing the created view.</returns>
+        /// <param name="createViewRequest">A <see cref="CreateViewRequest"/> object containing details for the new view, such as its name, type, and settings.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a <see cref="CreateTeamViewResponse"/> object with the created view's details.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="createViewRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         Task<CreateTeamViewResponse> CreateWorkspaceViewAsync(
             string workspaceId,
             CreateViewRequest createViewRequest,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Retrieves Views for a specific Space.
+        /// Retrieves all Views for a specific Space.
         /// </summary>
         /// <param name="spaceId">The ID of the Space.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A <see cref="GetViewsResponse"/> object containing a list of views in the Space.</returns>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a <see cref="GetViewsResponse"/> object with a list of views in the Space.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="spaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         Task<GetViewsResponse> GetSpaceViewsAsync(
             string spaceId,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Creates a new View in a Space.
+        /// Creates a new View within a specific Space.
         /// </summary>
         /// <param name="spaceId">The ID of the Space.</param>
-        /// <param name="createViewRequest">Details of the View to create.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A <see cref="CreateSpaceViewResponse"/> object containing the created view.</returns>
+        /// <param name="createViewRequest">A <see cref="CreateViewRequest"/> object containing details for the new view.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a <see cref="CreateSpaceViewResponse"/> object with the created view's details.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="spaceId"/> or <paramref name="createViewRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         Task<CreateSpaceViewResponse> CreateSpaceViewAsync(
             string spaceId,
             CreateViewRequest createViewRequest,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Retrieves Views for a specific Folder.
+        /// Retrieves all Views for a specific Folder.
         /// </summary>
         /// <param name="folderId">The ID of the Folder.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A <see cref="GetViewsResponse"/> object containing a list of views in the Folder.</returns>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a <see cref="GetViewsResponse"/> object with a list of views in the Folder.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="folderId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         Task<GetViewsResponse> GetFolderViewsAsync(
             string folderId,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Creates a new View in a Folder.
+        /// Creates a new View within a specific Folder.
         /// </summary>
         /// <param name="folderId">The ID of the Folder.</param>
-        /// <param name="createViewRequest">Details of the View to create.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A <see cref="CreateFolderViewResponse"/> object containing the created view.</returns>
+        /// <param name="createViewRequest">A <see cref="CreateViewRequest"/> object containing details for the new view.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a <see cref="CreateFolderViewResponse"/> object with the created view's details.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="folderId"/> or <paramref name="createViewRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         Task<CreateFolderViewResponse> CreateFolderViewAsync(
             string folderId,
             CreateViewRequest createViewRequest,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Retrieves Views for a specific List.
+        /// Retrieves all Views for a specific List.
         /// </summary>
         /// <param name="listId">The ID of the List.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A <see cref="GetViewsResponse"/> object containing a list of views in the List.</returns>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a <see cref="GetViewsResponse"/> object with a list of views in the List.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="listId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         Task<GetViewsResponse> GetListViewsAsync(
             string listId,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Creates a new View in a List.
+        /// Creates a new View within a specific List.
         /// </summary>
         /// <param name="listId">The ID of the List.</param>
-        /// <param name="createViewRequest">Details of the View to create.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A <see cref="CreateListViewResponse"/> object containing the created view.</returns>
+        /// <param name="createViewRequest">A <see cref="CreateViewRequest"/> object containing details for the new view.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a <see cref="CreateListViewResponse"/> object with the created view's details.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="listId"/> or <paramref name="createViewRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         Task<CreateListViewResponse> CreateListViewAsync(
             string listId,
             CreateViewRequest createViewRequest,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Retrieves details of a specific View.
+        /// Retrieves details of a specific View by its ID.
         /// </summary>
         /// <param name="viewId">The ID of the View.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A <see cref="GetViewResponse"/> object containing details of the view.</returns>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a <see cref="GetViewResponse"/> object with the view's details.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="viewId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as view not found.</exception>
         Task<GetViewResponse> GetViewAsync(
             string viewId,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Updates a View.
+        /// Updates an existing View.
         /// </summary>
-        /// <param name="viewId">The ID of the View.</param>
-        /// <param name="updateViewRequest">Details for updating the View.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A <see cref="UpdateViewResponse"/> object containing the updated view.</returns>
+        /// <param name="viewId">The ID of the View to update.</param>
+        /// <param name="updateViewRequest">An <see cref="UpdateViewRequest"/> object containing the updated details for the view.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains an <see cref="UpdateViewResponse"/> object with the updated view's details.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="viewId"/> or <paramref name="updateViewRequest"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         Task<UpdateViewResponse> UpdateViewAsync(
             string viewId,
             UpdateViewRequest updateViewRequest,
@@ -143,19 +168,23 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// Deletes a View.
         /// </summary>
         /// <param name="viewId">The ID of the View to delete.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous completion of the operation.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="viewId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         System.Threading.Tasks.Task DeleteViewAsync(
             string viewId,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Retrieves tasks visible in a specific View.
+        /// Retrieves tasks that are visible within a specific View, with pagination.
         /// </summary>
         /// <param name="viewId">The ID of the View.</param>
-        /// <param name="page">The page number to retrieve (0-indexed).</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A <see cref="GetViewTasksResponse"/> object containing a list of tasks and pagination details.</returns>
+        /// <param name="page">The page number of results to retrieve (0-indexed). The ClickUp API requires this parameter for this endpoint.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a <see cref="GetViewTasksResponse"/> object with a list of tasks and pagination information.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="viewId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors.</exception>
         Task<GetViewTasksResponse> GetViewTasksAsync(
             string viewId,
             int page,

--- a/src/ClickUp.Api.Client.Abstractions/Services/IWebhooksService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/IWebhooksService.cs
@@ -10,56 +10,68 @@ namespace ClickUp.Api.Client.Abstractions.Services
 {
     /// <summary>
     /// Represents the Webhooks operations in the ClickUp API.
+    /// This service allows for creating, retrieving, updating, and deleting webhooks for a Workspace.
     /// </summary>
     /// <remarks>
-    /// Based on endpoints like:
-    /// - GET /v2/team/{team_id}/webhook
-    /// - POST /v2/team/{team_id}/webhook
-    /// - PUT /v2/webhook/{webhook_id}
-    /// - DELETE /v2/webhook/{webhook_id}
+    /// Webhooks are used to receive notifications about events that happen in ClickUp.
+    /// Based on ClickUp API endpoints like:
+    /// <list type="bullet">
+    /// <item><description>GET /v2/team/{team_id}/webhook</description></item>
+    /// <item><description>POST /v2/team/{team_id}/webhook</description></item>
+    /// <item><description>PUT /v2/webhook/{webhook_id}</description></item>
+    /// <item><description>DELETE /v2/webhook/{webhook_id}</description></item>
+    /// </list>
     /// </remarks>
     public interface IWebhooksService
     {
         /// <summary>
-        /// Retrieves Webhooks created by the authenticated user for a specific Workspace.
+        /// Retrieves all Webhooks created by the authenticated user for a specific Workspace.
         /// </summary>
-        /// <param name="workspaceId">The ID of the Workspace (Team).</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A list of <see cref="Webhook"/> objects for the Workspace.</returns>
+        /// <param name="workspaceId">The ID of the Workspace (Team) for which to retrieve webhooks.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains an enumerable of <see cref="Webhook"/> objects.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as invalid workspace ID or authentication issues.</exception>
         Task<IEnumerable<Webhook>> GetWebhooksAsync(
             string workspaceId,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Creates a new Webhook.
+        /// Creates a new Webhook for a specific Workspace to listen for specified events.
         /// </summary>
         /// <param name="workspaceId">The ID of the Workspace (Team) where the webhook will be created.</param>
-        /// <param name="createWebhookRequest">Details of the Webhook to create.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>The created <see cref="Webhook"/> details, including its ID and secret.</returns>
+        /// <param name="createWebhookRequest">A <see cref="CreateWebhookRequest"/> object containing details for the new webhook, such as the endpoint URL and events to subscribe to.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the created <see cref="Webhook"/> details, including its ID and secret key.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="createWebhookRequest"/> is null.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as invalid endpoint URL or event types.</exception>
         Task<Webhook> CreateWebhookAsync(
             string workspaceId,
             CreateWebhookRequest createWebhookRequest,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Updates a Webhook.
+        /// Updates an existing Webhook's endpoint URL, subscribed events, or status.
         /// </summary>
         /// <param name="webhookId">The UUID of the Webhook to update.</param>
-        /// <param name="updateWebhookRequest">Details for updating the Webhook (endpoint, events, status).</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>The updated <see cref="Webhook"/> details.</returns>
+        /// <param name="updateWebhookRequest">An <see cref="UpdateWebhookRequest"/> object containing the updated details for the webhook.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the updated <see cref="Webhook"/> details.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="webhookId"/> or <paramref name="updateWebhookRequest"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as webhook not found or invalid update parameters.</exception>
         Task<Webhook> UpdateWebhookAsync(
             string webhookId,
             UpdateWebhookRequest updateWebhookRequest,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Deletes a Webhook.
+        /// Deletes an existing Webhook.
         /// </summary>
         /// <param name="webhookId">The UUID of the Webhook to delete.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>An awaitable task representing the asynchronous operation (void).</returns>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous completion of the operation.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="webhookId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as webhook not found or insufficient permissions.</exception>
         System.Threading.Tasks.Task DeleteWebhookAsync(
             string webhookId,
             CancellationToken cancellationToken = default);

--- a/src/ClickUp.Api.Client.Abstractions/Services/IWorkspacesService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/IWorkspacesService.cs
@@ -7,37 +7,49 @@ using ClickUp.Api.Client.Models.ResponseModels.Workspaces; // Assuming Workspace
 namespace ClickUp.Api.Client.Abstractions.Services
 {
     /// <summary>
-    /// Represents the Workspace (Team) level operations in the ClickUp API.
+    /// Represents Workspace (also referred to as Team in API v2) level operations in the ClickUp API.
+    /// This service provides methods to retrieve information about a Workspace's plan and seat usage.
     /// </summary>
     /// <remarks>
-    /// In ClickUp API v2, "Team" is often used to refer to a Workspace.
-    /// This service might also include User Group management in the future (often called "Teams" within a Workspace).
+    /// In the ClickUp API v2 documentation, "Team" is often synonymous with "Workspace".
+    /// This service focuses on Workspace-wide administrative information.
+    /// Operations related to User Groups (which are sometimes called "Teams" *within* a Workspace)
+    /// would typically be in a separate service or potentially expanded here if closely related.
+    /// Based on ClickUp API endpoints like:
+    /// <list type="bullet">
+    /// <item><description>GET /v2/team/{team_id}/seats</description></item>
+    /// <item><description>GET /v2/team/{team_id}/plan</description></item>
+    /// </list>
     /// </remarks>
     public interface IWorkspacesService
     {
         /// <summary>
-        /// Retrieves the seat usage for a specific Workspace.
+        /// Retrieves the current seat usage (members and guests) for a specific Workspace.
         /// </summary>
-        /// <param name="workspaceId">The ID of the Workspace (Team).</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="GetWorkspaceSeatsResponse"/> details.</returns>
+        /// <param name="workspaceId">The ID of the Workspace (Team) for which to retrieve seat usage.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="GetWorkspaceSeatsResponse"/> with details about member and guest seats.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as invalid workspace ID or authentication issues.</exception>
         Task<GetWorkspaceSeatsResponse> GetWorkspaceSeatsAsync(
             string workspaceId,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Retrieves the current plan for a specific Workspace.
+        /// Retrieves the current subscription plan details for a specific Workspace.
         /// </summary>
-        /// <param name="workspaceId">The ID of the Workspace (Team).</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="GetWorkspacePlanResponse"/> details.</returns>
+        /// <param name="workspaceId">The ID of the Workspace (Team) for which to retrieve plan details.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="GetWorkspacePlanResponse"/> with details about the Workspace's current plan.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="workspaceId"/> is null or empty.</exception>
+        /// <exception cref="ClickUp.Api.Client.Models.Exceptions.ClickUpApiException">Thrown for API-side errors, such as invalid workspace ID or authentication issues.</exception>
         Task<GetWorkspacePlanResponse> GetWorkspacePlanAsync(
             string workspaceId,
             CancellationToken cancellationToken = default);
 
-        // User Group (Teams within a Workspace) methods would go here if they were part of this service, e.g.:
-        // CuTask<IEnumerable<UserGroup>> GetUserGroupsAsync(string workspaceId, CancellationToken cancellationToken = default);
-        // CuTask<UserGroup> CreateUserGroupAsync(string workspaceId, CreateUserGroupRequest request, CancellationToken cancellationToken = default);
+        // User Group (Teams within a Workspace) methods could be added here in the future, for example:
+        // Task<IEnumerable<UserGroup>> GetUserGroupsAsync(string workspaceId, CancellationToken cancellationToken = default);
+        // Task<UserGroup> CreateUserGroupAsync(string workspaceId, CreateUserGroupRequest request, CancellationToken cancellationToken = default);
         // etc.
     }
 }

--- a/src/ClickUp.Api.Client.Models/RequestModels/Spaces/ModifyTagRequest.cs
+++ b/src/ClickUp.Api.Client.Models/RequestModels/Spaces/ModifyTagRequest.cs
@@ -3,25 +3,25 @@ using System.Text.Json.Serialization;
 namespace ClickUp.Api.Client.Models.RequestModels.Spaces;
 
 /// <summary>
-/// Represents the payload for creating or updating a tag.
-/// </summary>
-public record TagPayload
-{
-    [JsonPropertyName("name")]
-    public string Name { get; init; } = null!;
-
-    [JsonPropertyName("tag_fg")]
-    public string TagFg { get; init; } = null!;
-
-    [JsonPropertyName("tag_bg")]
-    public string TagBg { get; init; } = null!;
-}
-
-/// <summary>
 /// Represents the request body for creating or updating a tag in a Space.
 /// </summary>
 public record ModifyTagRequest
 {
-    [JsonPropertyName("tag")]
-    public TagPayload Tag { get; init; } = null!;
+    /// <summary>
+    /// Gets or sets the name of the tag.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = null!;
+
+    /// <summary>
+    /// Gets or sets the foreground color of the tag.
+    /// </summary>
+    [JsonPropertyName("tag_fg")]
+    public string TagForegroundColor { get; init; } = null!;
+
+    /// <summary>
+    /// Gets or sets the background color of the tag.
+    /// </summary>
+    [JsonPropertyName("tag_bg")]
+    public string TagBackgroundColor { get; init; } = null!;
 }


### PR DESCRIPTION
Completed XML documentation for all service interfaces in `src/ClickUp.Api.Client.Abstractions/Services/`.

- Added missing XML docs for ITaskChecklistsService, IUsersService, IViewsService, IWebhooksService, and IWorkspacesService.
- Reviewed and confirmed existing XML docs for other interfaces.
- Corrected the structure of `ModifyTagRequest` DTO to align with API.
- Made `dependsOnTaskId` and `dependencyOfTaskId` parameters nullable in `ITaskRelationshipsService.DeleteDependencyAsync` to better reflect API usage and updated its XML documentation accordingly.
- Updated `ICommentsService.CreateThreadedCommentAsync` return type to `Task<CreateCommentResponse>` for consistency and API accuracy.
- Updated `docs/plans/updatedPlans/core/01-CoreModelsAndAbstractions.md` to mark XML documentation tasks as complete.