### PR TITLE
Fix: Resolve build and test errors

### DIFF
--- a/src/ClickUp.Api.Client.Abstractions/Services/IAttachmentsService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/IAttachmentsService.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using ClickUp.Api.Client.Models.Responses.Attachments;
+using ClickUp.Api.Client.Models.ResponseModels.Attachments;
 
 namespace ClickUp.Api.Client.Abstractions.Services
 {

--- a/src/ClickUp.Api.Client.Models/RequestModels/Docs/SearchDocsRequest.cs
+++ b/src/ClickUp.Api.Client.Models/RequestModels/Docs/SearchDocsRequest.cs
@@ -6,53 +6,80 @@ namespace ClickUp.Api.Client.Models.RequestModels.Docs;
 /// <summary>
 /// Represents the request model for searching documents.
 /// </summary>
-public class SearchDocsRequest
+public record SearchDocsRequest
 {
     /// <summary>
     /// Gets or sets the search query string.
     /// </summary>
-    [JsonPropertyName("query")]
-    public string Query { get; set; } = null!;
+    [JsonPropertyName("q")] // Corrected based on usage in DocsService.cs
+    public string Query { get; init; } = string.Empty;
 
     /// <summary>
     /// Gets or sets a list of Space IDs to filter the search by.
     /// </summary>
     [JsonPropertyName("space_ids")]
-    public List<string>? SpaceIds { get; set; }
+    public List<string>? SpaceIds { get; init; }
 
     /// <summary>
     /// Gets or sets a list of Folder IDs to filter the search by.
     /// </summary>
     [JsonPropertyName("folder_ids")]
-    public List<string>? FolderIds { get; set; }
+    public List<string>? FolderIds { get; init; }
 
     /// <summary>
     /// Gets or sets a list of List IDs to filter the search by.
     /// </summary>
     [JsonPropertyName("list_ids")]
-    public List<string>? ListIds { get; set; }
+    public List<string>? ListIds { get; init; }
 
     /// <summary>
     /// Gets or sets a list of CuTask IDs to filter the search by (e.g., docs linked to these tasks).
     /// </summary>
     [JsonPropertyName("task_ids")]
-    public List<string>? TaskIds { get; set; }
+    public List<string>? TaskIds { get; init; }
 
     /// <summary>
     /// Gets or sets a value indicating whether to include archived documents in the search results.
+    /// Corresponds to the 'archived' query parameter.
     /// </summary>
-    [JsonPropertyName("include_archived")]
-    public bool? IncludeArchived { get; set; }
+    [JsonPropertyName("archived")]
+    public bool? IncludeArchived { get; init; }
 
     /// <summary>
     /// Gets or sets the maximum number of documents to return.
     /// </summary>
     [JsonPropertyName("limit")]
-    public int? Limit { get; set; }
+    public int? Limit { get; init; }
 
     /// <summary>
     /// Gets or sets the cursor for pagination, used to retrieve the next set of results.
     /// </summary>
     [JsonPropertyName("cursor")]
-    public string? Cursor { get; set; }
+    public string? Cursor { get; init; }
+
+    /// <summary>
+    /// Gets or sets the Parent ID to filter by (e.g., Doc ID for pages).
+    /// </summary>
+    [JsonPropertyName("parent_id")]
+    public string? ParentId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the Parent Type (e.g., 1 for Doc, 2 for Page).
+    /// </summary>
+    [JsonPropertyName("parent_type")]
+    public int? ParentType { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include deleted documents in the search results.
+    /// Corresponds to the 'deleted' query parameter.
+    /// </summary>
+    [JsonPropertyName("deleted")]
+    public bool? IncludeDeleted { get; init; }
+
+    /// <summary>
+    /// Gets or sets the Creator ID to filter by.
+    /// Corresponds to the 'creator' query parameter.
+    /// </summary>
+    [JsonPropertyName("creator")]
+    public int? CreatorId { get; init; }
 }

--- a/src/ClickUp.Api.Client.Tests/ServiceTests/AttachmentsServiceTests.cs
+++ b/src/ClickUp.Api.Client.Tests/ServiceTests/AttachmentsServiceTests.cs
@@ -4,7 +4,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using ClickUp.Api.Client.Abstractions.Http;
-using ClickUp.Api.Client.Models.Responses.Attachments; // Changed to use Response DTO
+using ClickUp.Api.Client.Models.ResponseModels.Attachments; // Changed to use Response DTO
 using ClickUp.Api.Client.Models.Entities.Users; // For User model within response
 using ClickUp.Api.Client.Services;
 using Moq;
@@ -39,7 +39,7 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
             var expectedResponse = new CreateTaskAttachmentResponse(
                 Id: "generated-id",
                 Version: "1",
-                Date: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                Date: DateTimeOffset.UtcNow,
                 Title: fileName,
                 Extension: "txt",
                 ThumbnailSmall: "http://example.com/thumb_small.txt",
@@ -100,7 +100,7 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
 
             var mockUser = new User(Id: 124, Username: "Test User 2", Email: "test2@example.com", Color: "#000000", ProfilePicture: null, Initials: "TU2", ProfileInfo: null);
             var expectedResponse = new CreateTaskAttachmentResponse(
-                Id: "id", Version: "v", Date: 123, Title: fileName, Extension: "ext", ThumbnailSmall: "ts",
+                Id: "id", Version: "v", Date: DateTimeOffset.FromUnixTimeMilliseconds(123), Title: fileName, Extension: "ext", ThumbnailSmall: "ts",
                 ThumbnailLarge: "tl", Url: "url", UrlWQuery: "url?q=2", UrlWHost: "host2/url",
                 IsFolder: false, ParentId: "parent2", Size: 2048, TotalComments: 1, ResolvedComments: 0,
                 User: mockUser, Deleted: false, Orientation: null, Type: 2, Source: 2,

--- a/src/ClickUp.Api.Client.Tests/ServiceTests/TaskServiceTests.cs
+++ b/src/ClickUp.Api.Client.Tests/ServiceTests/TaskServiceTests.cs
@@ -39,8 +39,8 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
                 MarkdownDescription: "Sample markdown description",
                 Status: new Models.Common.Status("open", "Open", 0, "open"), // Corrected namespace
                 OrderIndex: "1.0",
-                DateCreated: "1678886400000", // Example timestamp
-                DateUpdated: "1678886400000",
+                DateCreated: DateTimeOffset.FromUnixTimeMilliseconds(1678886400000L), // Example timestamp
+                DateUpdated: DateTimeOffset.FromUnixTimeMilliseconds(1678886400000L),
                 DateClosed: null,
                 Archived: false,
                 Creator: new User(1, "Test User", "test@example.com", "#FFFFFF", "http://example.com/pic.jpg", "TU", null), // Corrected constructor

--- a/src/ClickUp.Api.Client/Services/CommentService.cs
+++ b/src/ClickUp.Api.Client/Services/CommentService.cs
@@ -221,9 +221,9 @@ namespace ClickUp.Api.Client.Services
             return UpdateCommentAsync(commentId, updateCommentRequest, cancellationToken);
         }
 
-        Task ICommentsService.CreateThreadedCommentAsync(string commentId, CreateCommentRequest createCommentRequest, CancellationToken cancellationToken)
+        async Task<CreateCommentResponse> ICommentsService.CreateThreadedCommentAsync(string commentId, CreateCommentRequest createCommentRequest, CancellationToken cancellationToken)
         {
-            return CreateThreadedCommentAsync(commentId, createCommentRequest, cancellationToken);
+            return await CreateThreadedCommentAsync(commentId, createCommentRequest, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
- Corrected namespace for CreateTaskAttachmentResponse in IAttachmentsService and AttachmentsServiceTests.
- Fixed explicit interface implementation return type in CommentService.
- Changed SearchDocsRequest to a record and added missing fields to resolve errors in DocsService.
- Corrected DateTimeOffset initializations in TaskServiceTests and AttachmentsServiceTests to fix test failures.