### PR TITLE
feat: Implement TaskService methods and add logging to services

### DIFF
--- a/docs/plans/updatedPlans/documentation/08-ApiDocumentation.md
+++ b/docs/plans/updatedPlans/documentation/08-ApiDocumentation.md
@@ -38,14 +38,14 @@ This document outlines the plan for setting up and generating comprehensive API 
 ## 2. XML Documentation Comments
 
 - [x] **Mandatory for all public types and members.**
-    *(Status: Some XML comments exist, e.g., in `ITasksService.cs` and `CuTask.cs`. However, comprehensive coverage across all public APIs is needed.)*
-- [x] **Standard XML Tags:** Use `<summary>`, `<param>`, `<returns>`, etc.
-- [ ] **Enable XML Documentation File Generation in `.csproj` files:**
-    - [x] Add `<GenerateDocumentationFile>true</GenerateDocumentationFile>` to: (Completed 2024-07-12)
+    *(Status: Core interfaces and models are well-documented. Service implementations use `inheritdoc`. Comprehensive coverage across all utility/internal types may still be ongoing.)*
+- [x] **Standard XML Tags:** Use `<summary>`, `<param>`, `<returns>`, etc. (Confirmed in documented code.)
+- [x] **Enable XML Documentation File Generation in `.csproj` files:** (Verified 2024-07-15)
+    - [x] Add `<GenerateDocumentationFile>true</GenerateDocumentationFile>` to: (Completed 2024-07-12, Verified 2024-07-15)
         - [x] `src/ClickUp.Api.Client.Abstractions/ClickUp.Api.Client.Abstractions.csproj`
         - [x] `src/ClickUp.Api.Client.Models/ClickUp.Api.Client.Models.csproj`
         - [x] `src/ClickUp.Api.Client/ClickUp.Api.Client.csproj`
-- [x] **Review and Enhance Existing Comments:** (Completed 2024-07-12 - Interfaces reviewed and found complete. Service implementations use `inheritdoc`.) A full pass is required to ensure completeness and accuracy.
+- [x] **Review and Enhance Existing Comments:** (Interfaces reviewed and found complete. Service implementations use `inheritdoc`. Ongoing for full SDK depth.)
 
 ## 3. Conceptual Documentation (Articles)
 
@@ -82,6 +82,6 @@ This document outlines the plan for setting up and generating comprehensive API 
 - [ ] Thoroughly review all generated documentation once available.
 - [ ] Check links, formatting, code examples.
 
-**Overall Status:** The plan for DocFX setup and documentation generation is clear. However, the actual implementation (DocFX initialization, comprehensive XML comments, conceptual articles, build workflow) is largely pending. Some initial XML comments exist in the code, but generation of the XML documentation file is not yet enabled in the project files.
+**Overall Status:** The plan for DocFX setup and documentation generation is clear. XML documentation file generation is enabled in project files, and core components are documented. However, the DocFX project itself, conceptual articles, and the build workflow are largely pending.
 ```
 ```

--- a/docs/plans/updatedPlans/examples/09-ExampleProjects.md
+++ b/docs/plans/updatedPlans/examples/09-ExampleProjects.md
@@ -84,9 +84,9 @@ This document outlines the plan for developing showcase example projects that de
         - [x] `Serilog.Extensions.Hosting` / `Serilog.Sinks.Console` (or other logger) - Added Serilog.
 
 - [ ] **Scenarios to Demonstrate:** (All scenarios are pending implementation within the worker logic)
-    - [x] **1. Initialization and Configuration:**
-        - [ ] DI setup for `AddClickUpClient` in `Program.cs`. (Placeholder for this is set, actual `AddClickUpClient` call to be added when worker logic uses it)
-        - [x] API token configured via `appsettings.json` (needs `ClickUpApiOptions` section). (Configuration for options is set up in Program.cs)
+    - [ ] **1. Initialization and Configuration:**
+        - [ ] DI setup for `AddClickUpClient` in `Program.cs`. (Placeholder for this is set, actual `AddClickUpClient` call to be added when worker logic uses it. `ClickUpClientOptions` are not yet explicitly configured/bound in Worker's `Program.cs`.)
+        - [x] API token can be configured via `appsettings.json`/user secrets. (Configuration providers are set up in `Program.cs`; binding happens via `AddClickUpClient` which is planned).
     - [ ] **2. Periodic Polling Example (e.g., Check for New Tasks):**
         - [ ] Implement in `Worker.cs` or a new `BackgroundService`.
         - [ ] Inject `ITasksService`, `ILogger`.

--- a/docs/plans/updatedPlans/exceptions/04-ExceptionHandling.md
+++ b/docs/plans/updatedPlans/exceptions/04-ExceptionHandling.md
@@ -63,12 +63,12 @@ All custom exceptions inherit from a base `ClickUpApiException`.
 
 A DTO to represent the common error structure returned by the ClickUp API.
 
-- [ ] **1. `ClickUpErrorResponse.cs`**
-    - [ ] Location: `src/ClickUp.Api.Client.Models/Responses/Shared/` (or similar) - **Not found.** `ApiConnection.cs` currently does not deserialize into a specific error DTO. It reads raw error content.
-    - [ ] Properties:
-        - [ ] `[JsonPropertyName("err")] public string? ErrorMessage { get; set; }`
-        - [ ] `[JsonPropertyName("ECODE")] public string? ErrorCode { get; set; }`
-    *Action: This DTO should be created to improve error parsing in `ApiConnection.HandleErrorResponseAsync`.*
+- [x] **1. `ClickUpErrorResponse.cs`**
+    - [x] Location: `src/ClickUp.Api.Client.Models/Responses/Shared/ClickUpErrorResponse.cs` - Implemented.
+    - [x] Properties:
+        - [x] `[JsonPropertyName("err")] public string ErrorMessage { get; set; }`
+        - [x] `[JsonPropertyName("ECODE")] public string ErrorCode { get; set; }`
+    *Action: This DTO has been created and is used in `ApiConnection.HandleErrorResponseAsync`.*
 
 ## 3. Centralized Error Handling Logic Helper
 
@@ -80,13 +80,13 @@ The logic is centralized within `ApiConnection.HandleErrorResponseAsync`.
         - [x] If `response.IsSuccessStatusCode`, it's not called (logic is `if (!response.IsSuccessStatusCode) { await HandleErrorResponseAsync... }`).
         - [x] Otherwise:
             - [x] Reads the raw response body as a string: `string rawErrorContent = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);`
-            - [ ] Attempt to deserialize `rawErrorContent` into `ClickUpErrorResponse`. **(Currently not done, uses raw content directly for message, `apiErrorCode` is null).**
-            - [x] Extracts `errorMessage` (currently generic + status code, or `response.ReasonPhrase`).
-            - [x] `apiErrorCode` is currently passed as `null` to exception constructors.
+            - [x] Attempts to deserialize `rawErrorContent` into `ClickUpErrorResponse`. (Implemented)
+            - [x] Extracts `errorMessage` (from DTO if available, otherwise generic + status code, or `response.ReasonPhrase`).
+            - [x] `apiErrorCode` is populated from DTO if available, otherwise null. (Implemented)
             - [x] `httpStatus = response.StatusCode;` is used.
             - [x] Switch on `httpStatus`:
                 - [x] `case HttpStatusCode.BadRequest (400):`
-                - [x] `case HttpStatusCode.UnprocessableEntity (422):` -> `throw new ClickUpApiValidationException(...)` (ValidationErrors is null).
+                - [x] `case HttpStatusCode.UnprocessableEntity (422):` -> `throw new ClickUpApiValidationException(...)` (Detailed `ValidationErrors` dictionary is not yet parsed from raw content, passed as null).
                 - [x] `case HttpStatusCode.Unauthorized (401):`
                 - [x] `case HttpStatusCode.Forbidden (403):` -> `throw new ClickUpApiAuthenticationException(...)`.
                 - [x] `case HttpStatusCode.NotFound (404):` -> `throw new ClickUpApiNotFoundException(...)`.
@@ -116,8 +116,8 @@ The logic is centralized within `ApiConnection.HandleErrorResponseAsync`.
 ## 4. Plan Output
 - [x] This document `04-ExceptionHandling.md` has been updated with checkboxes.
 - [x] The exception class hierarchy is largely implemented as planned.
-- [ ] The `ClickUpErrorResponse` DTO is missing and should be implemented to improve error detail extraction.
-- [x] The logic in `ApiConnection.HandleErrorResponseAsync` implements most of the planned error handling, with some minor deviations (e.g., default exception for unmapped 4xx, no detailed `apiErrorCode` or `ValidationErrors` parsing yet).
+- [x] The `ClickUpErrorResponse` DTO has been implemented and is used for error detail extraction.
+- [x] The logic in `ApiConnection.HandleErrorResponseAsync` has been improved to parse `apiErrorCode` from the error DTO. Parsing detailed `ValidationErrors` and the default exception for unmapped 4xx remain as minor deviations/areas for enhancement.
 - [x] Service implementations are correctly integrated via `ApiConnection`.
 ```
 ```

--- a/docs/plans/updatedPlans/testing/07-TestingStrategy.md
+++ b/docs/plans/updatedPlans/testing/07-TestingStrategy.md
@@ -72,7 +72,7 @@ This document outlines the testing strategy for the ClickUp API SDK, covering un
 - [x] **Framework:** xUnit (assumed, consistent with unit tests).
 - [x] **Prerequisites:**
     - [ ] **Test ClickUp Workspace:** Required.
-    - [ ] **API Token:** Required, must be configurable and not in source control. `IntegrationTestBase.cs` likely handles configuration.
+    - [x] **API Token:** Required, must be configurable and not in source control. `IntegrationTestBase.cs` handles configuration via user secrets/environment variables.
     - [ ] **Test Data Setup/Teardown:** Needs strategy.
 
 - [x] **Key Areas for Integration Testing:**

--- a/src/ClickUp.Api.Client/Services/AttachmentsService.cs
+++ b/src/ClickUp.Api.Client/Services/AttachmentsService.cs
@@ -1,5 +1,6 @@
 using System.Text; // For StringBuilder query params
-
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using ClickUp.Api.Client.Abstractions.Http; // IApiConnection
 using ClickUp.Api.Client.Abstractions.Services;
 using ClickUp.Api.Client.Models.ResponseModels.Attachments;
@@ -15,15 +16,18 @@ namespace ClickUp.Api.Client.Services
     public class AttachmentsService : IAttachmentsService
     {
         private readonly IApiConnection _apiConnection;
+        private readonly ILogger<AttachmentsService> _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AttachmentsService"/> class.
         /// </summary>
         /// <param name="apiConnection">The API connection to use for making requests.</param>
-        /// <exception cref="ArgumentNullException">Thrown if apiConnection is null.</exception>
-        public AttachmentsService(IApiConnection apiConnection)
+        /// <param name="logger">The logger for this service.</param>
+        /// <exception cref="ArgumentNullException">Thrown if apiConnection or logger is null.</exception>
+        public AttachmentsService(IApiConnection apiConnection, ILogger<AttachmentsService> logger)
         {
             _apiConnection = apiConnection ?? throw new ArgumentNullException(nameof(apiConnection));
+            _logger = logger ?? NullLogger<AttachmentsService>.Instance;
         }
 
         private string BuildQueryString(Dictionary<string, string?> queryParams)
@@ -54,6 +58,7 @@ namespace ClickUp.Api.Client.Services
             string? teamId = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Creating task attachment for task ID: {TaskId}, FileName: {FileName}", taskId, fileName);
             var endpoint = $"task/{taskId}/attachment";
             var queryParams = new Dictionary<string, string?>();
             if (customTaskIds.HasValue) queryParams["custom_task_ids"] = customTaskIds.Value.ToString().ToLower();

--- a/src/ClickUp.Api.Client/Services/AuthorizationService.cs
+++ b/src/ClickUp.Api.Client/Services/AuthorizationService.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 using ClickUp.Api.Client.Abstractions.Http; // IApiConnection
 using ClickUp.Api.Client.Abstractions.Services;
 using ClickUp.Api.Client.Models; // For ClickUpWorkspace
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using ClickUp.Api.Client.Models.Entities.Users; // For User
 using ClickUp.Api.Client.Models.RequestModels.Authorization;
 using ClickUp.Api.Client.Models.ResponseModels.Authorization;
@@ -19,15 +21,18 @@ namespace ClickUp.Api.Client.Services
     public class AuthorizationService : IAuthorizationService
     {
         private readonly IApiConnection _apiConnection;
+        private readonly ILogger<AuthorizationService> _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthorizationService"/> class.
         /// </summary>
         /// <param name="apiConnection">The API connection to use for making requests.</param>
-        /// <exception cref="ArgumentNullException">Thrown if apiConnection is null.</exception>
-        public AuthorizationService(IApiConnection apiConnection)
+        /// <param name="logger">The logger for this service.</param>
+        /// <exception cref="ArgumentNullException">Thrown if apiConnection or logger is null.</exception>
+        public AuthorizationService(IApiConnection apiConnection, ILogger<AuthorizationService> logger)
         {
             _apiConnection = apiConnection ?? throw new ArgumentNullException(nameof(apiConnection));
+            _logger = logger ?? NullLogger<AuthorizationService>.Instance;
         }
 
         /// <inheritdoc />
@@ -37,6 +42,7 @@ namespace ClickUp.Api.Client.Services
             string code,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting access token for Client ID: {ClientId}", clientId);
             var endpoint = "oauth/token";
             var payload = new GetAccessTokenRequest(clientId, clientSecret, code);
             return await _apiConnection.PostAsync<GetAccessTokenRequest, GetAccessTokenResponse>(endpoint, payload, cancellationToken);
@@ -45,6 +51,7 @@ namespace ClickUp.Api.Client.Services
         /// <inheritdoc />
         public async Task<User?> GetAuthorizedUserAsync(CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting authorized user");
             var endpoint = "user";
             var response = await _apiConnection.GetAsync<GetAuthorizedUserResponse>(endpoint, cancellationToken);
             return response?.User;
@@ -53,6 +60,7 @@ namespace ClickUp.Api.Client.Services
         /// <inheritdoc />
         public async Task<IEnumerable<ClickUpWorkspace>?> GetAuthorizedWorkspacesAsync(CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting authorized workspaces");
             var endpoint = "team";
             var response = await _apiConnection.GetAsync<GetAuthorizedWorkspacesResponse>(endpoint, cancellationToken);
             return response?.Workspaces; // Changed from Teams to Workspaces to match DTO property name


### PR DESCRIPTION
Completed implementation of GetFilteredTeamTasksAsync in TaskService.cs. Refactored MergeTasksAsync in TaskService.cs to correctly handle merging multiple source tasks based on the ITasksService interface and ClickUp API specification. Removed an incorrect internal overload.

Initiated consistent ILogger injection and basic logging across services:
- TaskService.cs: Added ILogger injection and logging statements to all public methods.
- ListsService.cs: Added ILogger injection and logging statements to all public methods.
- AttachmentsService.cs: Added ILogger injection and logging statements.
- AuthorizationService.cs: Added ILogger injection and logging statements.
- ChatService.cs: Added ILogger injection and started adding logging statements (partially complete).

This work addresses the first part of Phase 1: 'Complete Core Service Method Implementations' from the consolidated plan.