### PR TITLE
Refactor MergeTasksAsync to align with API capabilities

### DIFF
--- a/docs/plans/updatedPlans/ConsolidatedPlan.md
+++ b/docs/plans/updatedPlans/ConsolidatedPlan.md
@@ -9,7 +9,7 @@ This plan consolidates uncompleted items from the 11 detailed plan documents in 
     - *File:* `src/ClickUp.Api.Client/Services/TaskService.cs`
     - *Why:* Core functionality for fetching tasks at a workspace level. Currently throws `NotImplementedException`.
     - *Ref:* `docs/plans/updatedPlans/services/02-ServiceImplementations.md`
-- [ ] **Task:** Clarify ClickUp API mapping and then correctly implement the `MergeTasksAsync` overloads in `TaskService.cs` and `ITasksService.cs`.
+- [x] **Task:** Clarify ClickUp API mapping and then correctly implement the `MergeTasksAsync` overloads in `TaskService.cs` and `ITasksService.cs`.
     - *Files:* `src/ClickUp.Api.Client/Services/TaskService.cs`, `src/ClickUp.Api.Client.Abstractions/Services/ITasksService.cs`
     - *Why:* Ensure task merging functionality is correct and usable; current implementation notes ambiguity.
     - *Ref:* `docs/plans/updatedPlans/services/02-ServiceImplementations.md`

--- a/src/ClickUp.Api.Client.Abstractions/Services/ITasksService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/ITasksService.cs
@@ -236,20 +236,16 @@ namespace ClickUp.Api.Client.Abstractions.Services
         /// </summary>
         /// <param name="targetTaskId">The unique identifier of the target Task into which other Tasks will be merged.</param>
         /// <param name="mergeTasksRequest">An object containing a list of source Task IDs to be merged into the target Task.</param>
-        /// <param name="customTaskIds">Optional. If set to <c>true</c>, all task IDs (target and source) are treated as custom task IDs. Defaults to <c>false</c>.</param>
-        /// <param name="teamId">Optional. The Workspace ID (formerly team_id). This is required if <paramref name="customTaskIds"/> is <c>true</c>.</param>
         /// <param name="cancellationToken">A token to observe while waiting for the task to complete, allowing cancellation of the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the updated target <see cref="CuTask"/>, reflecting the merge.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="targetTaskId"/> or <paramref name="mergeTasksRequest"/> is null, or if the list of source task IDs in the request is null or empty.</exception>
-        /// <exception cref="System.ArgumentException">Thrown if <paramref name="customTaskIds"/> is true but <paramref name="teamId"/> is not provided.</exception>
         /// <exception cref="Models.Exceptions.ClickUpApiNotFoundException">Thrown if the target Task or any of the source Tasks do not exist.</exception>
         /// <exception cref="Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to merge these Tasks.</exception>
         /// <exception cref="Models.Exceptions.ClickUpApiException">Thrown for other API call failures.</exception>
+        /// <remarks>The ClickUp API endpoint used for this operation (POST /task/{task_id}/merge) does not support custom task IDs.</remarks>
         Task<CuTask> MergeTasksAsync(
             string targetTaskId,
             MergeTasksRequest mergeTasksRequest,
-            bool? customTaskIds = null,
-            string? teamId = null,
             CancellationToken cancellationToken = default);
 
 


### PR DESCRIPTION
- Removes `customTaskIds` and `teamId` parameters from `MergeTasksAsync` in both the interface (`ITasksService.cs`) and implementation (`TaskService.cs`) as the ClickUp API endpoint for merging tasks does not support them.
- Updates XML documentation comments to reflect the signature change and note the API limitation.
- Improves logging within the `MergeTasksAsync` implementation.
- Marks the corresponding task as complete in `ConsolidatedPlan.md`.