### PR TITLE
Add ILogger to all services

### DIFF
--- a/docs/plans/updatedPlans/ConsolidatedPlan.md
+++ b/docs/plans/updatedPlans/ConsolidatedPlan.md
@@ -13,7 +13,7 @@ This plan consolidates uncompleted items from the 11 detailed plan documents in 
     - *Files:* `src/ClickUp.Api.Client/Services/TaskService.cs`, `src/ClickUp.Api.Client.Abstractions/Services/ITasksService.cs`
     - *Why:* Ensure task merging functionality is correct and usable; current implementation notes ambiguity.
     - *Ref:* `docs/plans/updatedPlans/services/02-ServiceImplementations.md`
-- [ ] **Task:** Review all service implementations in `src/ClickUp.Api.Client/Services/` for consistent `ILogger<XxxService>` injection in constructors and basic usage (e.g., logging entry/exit or errors).
+- [x] **Task:** Review all service implementations in `src/ClickUp.Api.Client/Services/` for consistent `ILogger<XxxService>` injection in constructors and basic usage (e.g., logging entry/exit or errors).
     - *Files:* All service files in `src/ClickUp.Api.Client/Services/`
     - *Why:* Improves observability and maintainability, aligns with original plan for constructor dependencies.
     - *Ref:* `docs/plans/updatedPlans/services/02-ServiceImplementations.md`

--- a/src/ClickUp.Api.Client/Services/CommentService.cs
+++ b/src/ClickUp.Api.Client/Services/CommentService.cs
@@ -11,6 +11,8 @@ using ClickUp.Api.Client.Models.Entities;
 using ClickUp.Api.Client.Models.Entities.Comments;
 using ClickUp.Api.Client.Models.RequestModels.Comments;
 using ClickUp.Api.Client.Models.ResponseModels.Comments; // For CreateCommentResponse and potential GetCommentsResponse
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ClickUp.Api.Client.Services
 {
@@ -20,15 +22,18 @@ namespace ClickUp.Api.Client.Services
     public class CommentService : ICommentsService
     {
         private readonly IApiConnection _apiConnection;
+        private readonly ILogger<CommentService> _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CommentService"/> class.
         /// </summary>
         /// <param name="apiConnection">The API connection to use for making requests.</param>
-        /// <exception cref="ArgumentNullException">Thrown if apiConnection is null.</exception>
-        public CommentService(IApiConnection apiConnection)
+        /// <param name="logger">The logger for this service.</param>
+        /// <exception cref="ArgumentNullException">Thrown if apiConnection or logger is null.</exception>
+        public CommentService(IApiConnection apiConnection, ILogger<CommentService> logger)
         {
             _apiConnection = apiConnection ?? throw new ArgumentNullException(nameof(apiConnection));
+            _logger = logger ?? NullLogger<CommentService>.Instance;
         }
 
         private string BuildQueryString(Dictionary<string, string?> queryParams)
@@ -59,6 +64,7 @@ namespace ClickUp.Api.Client.Services
             string? startId = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting task comments for task ID: {TaskId}, Start: {Start}, StartId: {StartId}", taskId, start, startId);
             var endpoint = $"task/{taskId}/comment";
             var queryParams = new Dictionary<string, string?>();
             if (customTaskIds.HasValue) queryParams["custom_task_ids"] = customTaskIds.Value.ToString().ToLower();
@@ -79,6 +85,7 @@ namespace ClickUp.Api.Client.Services
             string? teamId = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Creating task comment for task ID: {TaskId}", taskId);
             var endpoint = $"task/{taskId}/comment";
             var queryParams = new Dictionary<string, string?>();
             if (customTaskIds.HasValue) queryParams["custom_task_ids"] = customTaskIds.Value.ToString().ToLower();
@@ -100,6 +107,7 @@ namespace ClickUp.Api.Client.Services
             string? startId = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting chat view comments for view ID: {ViewId}, Start: {Start}, StartId: {StartId}", viewId, start, startId);
             var endpoint = $"view/{viewId}/comment";
             var queryParams = new Dictionary<string, string?>();
             if (start.HasValue) queryParams["start"] = start.Value.ToString();
@@ -116,6 +124,7 @@ namespace ClickUp.Api.Client.Services
             CreateCommentRequest createCommentRequest,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Creating chat view comment for view ID: {ViewId}", viewId);
             var endpoint = $"view/{viewId}/comment";
             var response = await _apiConnection.PostAsync<CreateCommentRequest, CreateCommentResponse>(endpoint, createCommentRequest, cancellationToken);
             if (response == null)
@@ -132,6 +141,7 @@ namespace ClickUp.Api.Client.Services
             string? startId = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting list comments for list ID: {ListId}, Start: {Start}, StartId: {StartId}", listId, start, startId);
             var endpoint = $"list/{listId}/comment";
             var queryParams = new Dictionary<string, string?>();
             if (start.HasValue) queryParams["start"] = start.Value.ToString();
@@ -148,6 +158,7 @@ namespace ClickUp.Api.Client.Services
             CreateCommentRequest createCommentRequest,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Creating list comment for list ID: {ListId}", listId);
             var endpoint = $"list/{listId}/comment";
             var response = await _apiConnection.PostAsync<CreateCommentRequest, CreateCommentResponse>(endpoint, createCommentRequest, cancellationToken);
             if (response == null)
@@ -163,6 +174,7 @@ namespace ClickUp.Api.Client.Services
             UpdateCommentRequest updateCommentRequest,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Updating comment ID: {CommentId}", commentId);
             var endpoint = $"comment/{commentId}";
             var comment = await _apiConnection.PutAsync<UpdateCommentRequest, Comment>(endpoint, updateCommentRequest, cancellationToken);
             if (comment == null)
@@ -177,6 +189,7 @@ namespace ClickUp.Api.Client.Services
             string commentId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Deleting comment ID: {CommentId}", commentId);
             var endpoint = $"comment/{commentId}";
             await _apiConnection.DeleteAsync(endpoint, cancellationToken);
         }
@@ -191,6 +204,7 @@ namespace ClickUp.Api.Client.Services
             string commentId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting threaded comments for comment ID: {CommentId}", commentId);
              // The API doc suggests "GET /v2/comment/{comment_id}/reply" but this is not standard.
              // More likely, one gets a comment and its 'replies' field, or this endpoint is a special case.
              // Let's assume it's a direct endpoint that returns a list of comments.
@@ -207,6 +221,7 @@ namespace ClickUp.Api.Client.Services
             CreateCommentRequest createCommentRequest,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Creating threaded comment for comment ID: {CommentId}", commentId);
             var endpoint = $"comment/{commentId}/reply";
             var response = await _apiConnection.PostAsync<CreateCommentRequest, CreateCommentResponse>(endpoint, createCommentRequest, cancellationToken);
             if (response == null)

--- a/src/ClickUp.Api.Client/Services/CustomFieldsService.cs
+++ b/src/ClickUp.Api.Client/Services/CustomFieldsService.cs
@@ -11,6 +11,8 @@ using ClickUp.Api.Client.Models.Entities.CustomFields; // For Field
 using ClickUp.Api.Client.Models.RequestModels.CustomFields;
 using ClickUp.Api.Client.Models.ResponseModels.CustomFields; // Assuming GetCustomFieldsResponse exists
 using System.Linq; // For Enumerable.Empty
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ClickUp.Api.Client.Services
 {
@@ -20,15 +22,18 @@ namespace ClickUp.Api.Client.Services
     public class CustomFieldsService : ICustomFieldsService
     {
         private readonly IApiConnection _apiConnection;
+        private readonly ILogger<CustomFieldsService> _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CustomFieldsService"/> class.
         /// </summary>
         /// <param name="apiConnection">The API connection to use for making requests.</param>
-        /// <exception cref="ArgumentNullException">Thrown if apiConnection is null.</exception>
-        public CustomFieldsService(IApiConnection apiConnection)
+        /// <param name="logger">The logger for this service.</param>
+        /// <exception cref="ArgumentNullException">Thrown if apiConnection or logger is null.</exception>
+        public CustomFieldsService(IApiConnection apiConnection, ILogger<CustomFieldsService> logger)
         {
             _apiConnection = apiConnection ?? throw new ArgumentNullException(nameof(apiConnection));
+            _logger = logger ?? NullLogger<CustomFieldsService>.Instance;
         }
 
         private string BuildQueryString(Dictionary<string, string?> queryParams)
@@ -55,6 +60,7 @@ namespace ClickUp.Api.Client.Services
             string listId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting accessible custom fields for list ID: {ListId}", listId);
             // This endpoint retrieves all fields accessible by a List, including those from parent Folders, Spaces, and the Workspace.
             var endpoint = $"list/{listId}/field";
             var response = await _apiConnection.GetAsync<GetAccessibleCustomFieldsResponse>(endpoint, cancellationToken); // API returns {"fields": [...]}
@@ -66,6 +72,7 @@ namespace ClickUp.Api.Client.Services
             string folderId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting custom fields for folder ID: {FolderId}", folderId);
             var endpoint = $"folder/{folderId}/field";
             var response = await _apiConnection.GetAsync<GetAccessibleCustomFieldsResponse>(endpoint, cancellationToken); // API returns {"fields": [...]}
             return response?.Fields ?? Enumerable.Empty<Field>();
@@ -76,6 +83,7 @@ namespace ClickUp.Api.Client.Services
             string spaceId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting custom fields for space ID: {SpaceId}", spaceId);
             var endpoint = $"space/{spaceId}/field";
             var response = await _apiConnection.GetAsync<GetAccessibleCustomFieldsResponse>(endpoint, cancellationToken); // API returns {"fields": [...]}
             return response?.Fields ?? Enumerable.Empty<Field>();
@@ -86,6 +94,7 @@ namespace ClickUp.Api.Client.Services
             string workspaceId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting custom fields for workspace ID: {WorkspaceId}", workspaceId);
             var endpoint = $"team/{workspaceId}/field"; // team_id is workspaceId
             var response = await _apiConnection.GetAsync<GetAccessibleCustomFieldsResponse>(endpoint, cancellationToken); // API returns {"fields": [...]}
             return response?.Fields ?? Enumerable.Empty<Field>();
@@ -100,6 +109,7 @@ namespace ClickUp.Api.Client.Services
             string? teamId = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Setting custom field value for task ID: {TaskId}, Field ID: {FieldId}", taskId, fieldId);
             var endpoint = $"task/{taskId}/field/{fieldId}";
             var queryParams = new Dictionary<string, string?>();
             if (customTaskIds.HasValue) queryParams["custom_task_ids"] = customTaskIds.Value.ToString().ToLower();
@@ -118,6 +128,7 @@ namespace ClickUp.Api.Client.Services
             string? teamId = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Removing custom field value for task ID: {TaskId}, Field ID: {FieldId}", taskId, fieldId);
             var endpoint = $"task/{taskId}/field/{fieldId}";
             var queryParams = new Dictionary<string, string?>();
             if (customTaskIds.HasValue) queryParams["custom_task_ids"] = customTaskIds.Value.ToString().ToLower();

--- a/src/ClickUp.Api.Client/Services/FoldersService.cs
+++ b/src/ClickUp.Api.Client/Services/FoldersService.cs
@@ -11,6 +11,8 @@ using ClickUp.Api.Client.Models.Entities;
 using ClickUp.Api.Client.Models.Entities.Folders;
 using ClickUp.Api.Client.Models.RequestModels.Folders;
 using ClickUp.Api.Client.Models.ResponseModels.Folders; // Assuming GetFoldersResponse exists
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ClickUp.Api.Client.Services
 {
@@ -20,15 +22,18 @@ namespace ClickUp.Api.Client.Services
     public class FoldersService : IFoldersService
     {
         private readonly IApiConnection _apiConnection;
+        private readonly ILogger<FoldersService> _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FoldersService"/> class.
         /// </summary>
         /// <param name="apiConnection">The API connection to use for making requests.</param>
-        /// <exception cref="ArgumentNullException">Thrown if apiConnection is null.</exception>
-        public FoldersService(IApiConnection apiConnection)
+        /// <param name="logger">The logger for this service.</param>
+        /// <exception cref="ArgumentNullException">Thrown if apiConnection or logger is null.</exception>
+        public FoldersService(IApiConnection apiConnection, ILogger<FoldersService> logger)
         {
             _apiConnection = apiConnection ?? throw new ArgumentNullException(nameof(apiConnection));
+            _logger = logger ?? NullLogger<FoldersService>.Instance;
         }
 
         private string BuildQueryString(Dictionary<string, string?> queryParams)
@@ -56,6 +61,7 @@ namespace ClickUp.Api.Client.Services
             bool? archived = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting folders for space ID: {SpaceId}, Archived: {Archived}", spaceId, archived);
             var endpoint = $"space/{spaceId}/folder";
             var queryParams = new Dictionary<string, string?>();
             if (archived.HasValue) queryParams["archived"] = archived.Value.ToString().ToLower();
@@ -71,6 +77,7 @@ namespace ClickUp.Api.Client.Services
             CreateFolderRequest createFolderRequest,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Creating folder in space ID: {SpaceId}, Name: {FolderName}", spaceId, createFolderRequest.Name);
             var endpoint = $"space/{spaceId}/folder";
             var folder = await _apiConnection.PostAsync<CreateFolderRequest, Folder>(endpoint, createFolderRequest, cancellationToken);
             if (folder == null)
@@ -85,6 +92,7 @@ namespace ClickUp.Api.Client.Services
             string folderId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting folder ID: {FolderId}", folderId);
             var endpoint = $"folder/{folderId}";
             var folder = await _apiConnection.GetAsync<Folder>(endpoint, cancellationToken);
             if (folder == null)
@@ -100,6 +108,7 @@ namespace ClickUp.Api.Client.Services
             UpdateFolderRequest updateFolderRequest,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Updating folder ID: {FolderId}, Name: {FolderName}", folderId, updateFolderRequest.Name);
             var endpoint = $"folder/{folderId}";
             var folder = await _apiConnection.PutAsync<UpdateFolderRequest, Folder>(endpoint, updateFolderRequest, cancellationToken);
             if (folder == null)
@@ -114,6 +123,7 @@ namespace ClickUp.Api.Client.Services
             string folderId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Deleting folder ID: {FolderId}", folderId);
             var endpoint = $"folder/{folderId}";
             await _apiConnection.DeleteAsync(endpoint, cancellationToken);
         }
@@ -125,6 +135,7 @@ namespace ClickUp.Api.Client.Services
             CreateFolderFromTemplateRequest createFolderFromTemplateRequest,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Creating folder from template ID: {TemplateId} in space ID: {SpaceId}, Name: {FolderName}", templateId, spaceId, createFolderFromTemplateRequest.Name);
             var endpoint = $"space/{spaceId}/folderTemplate/{templateId}"; // Corrected endpoint
             var folder = await _apiConnection.PostAsync<CreateFolderFromTemplateRequest, Folder>(endpoint, createFolderFromTemplateRequest, cancellationToken);
             if (folder == null)

--- a/src/ClickUp.Api.Client/Services/GoalsService.cs
+++ b/src/ClickUp.Api.Client/Services/GoalsService.cs
@@ -12,6 +12,8 @@ using ClickUp.Api.Client.Models.Entities.Goals;
 using ClickUp.Api.Client.Models.RequestModels.Goals;
 using ClickUp.Api.Client.Models.ResponseModels.Goals;
 using ClickUp.Api.Client.Models.ResponseModels; // For potential generic wrappers if needed
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ClickUp.Api.Client.Services
 {
@@ -21,15 +23,18 @@ namespace ClickUp.Api.Client.Services
     public class GoalsService : IGoalsService
     {
         private readonly IApiConnection _apiConnection;
+        private readonly ILogger<GoalsService> _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GoalsService"/> class.
         /// </summary>
         /// <param name="apiConnection">The API connection to use for making requests.</param>
-        /// <exception cref="ArgumentNullException">Thrown if apiConnection is null.</exception>
-        public GoalsService(IApiConnection apiConnection)
+        /// <param name="logger">The logger for this service.</param>
+        /// <exception cref="ArgumentNullException">Thrown if apiConnection or logger is null.</exception>
+        public GoalsService(IApiConnection apiConnection, ILogger<GoalsService> logger)
         {
             _apiConnection = apiConnection ?? throw new ArgumentNullException(nameof(apiConnection));
+            _logger = logger ?? NullLogger<GoalsService>.Instance;
         }
 
         private string BuildQueryString(Dictionary<string, string?> queryParams)
@@ -57,6 +62,7 @@ namespace ClickUp.Api.Client.Services
             bool? includeCompleted = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting goals for workspace ID: {WorkspaceId}, IncludeCompleted: {IncludeCompleted}", workspaceId, includeCompleted);
             var endpoint = $"team/{workspaceId}/goal"; // team_id is workspaceId
             var queryParams = new Dictionary<string, string?>();
             if (includeCompleted.HasValue) queryParams["include_completed"] = includeCompleted.Value.ToString().ToLower();
@@ -76,6 +82,7 @@ namespace ClickUp.Api.Client.Services
             CreateGoalRequest createGoalRequest,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Creating goal in workspace ID: {WorkspaceId}, Name: {GoalName}", workspaceId, createGoalRequest.Name);
             var endpoint = $"team/{workspaceId}/goal";
             var responseWrapper = await _apiConnection.PostAsync<CreateGoalRequest, GetGoalResponse>(endpoint, createGoalRequest, cancellationToken);
             if (responseWrapper?.Goal == null)
@@ -90,6 +97,7 @@ namespace ClickUp.Api.Client.Services
             string goalId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting goal ID: {GoalId}", goalId);
             var endpoint = $"goal/{goalId}";
             var responseWrapper = await _apiConnection.GetAsync<GetGoalResponse>(endpoint, cancellationToken);
             if (responseWrapper?.Goal == null)
@@ -105,6 +113,7 @@ namespace ClickUp.Api.Client.Services
             UpdateGoalRequest updateGoalRequest,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Updating goal ID: {GoalId}, Name: {GoalName}", goalId, updateGoalRequest.Name);
             var endpoint = $"goal/{goalId}";
             var responseWrapper = await _apiConnection.PutAsync<UpdateGoalRequest, GetGoalResponse>(endpoint, updateGoalRequest, cancellationToken);
             if (responseWrapper?.Goal == null)
@@ -119,6 +128,7 @@ namespace ClickUp.Api.Client.Services
             string goalId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Deleting goal ID: {GoalId}", goalId);
             var endpoint = $"goal/{goalId}";
             await _apiConnection.DeleteAsync(endpoint, cancellationToken);
         }
@@ -129,6 +139,7 @@ namespace ClickUp.Api.Client.Services
             CreateKeyResultRequest createKeyResultRequest,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Creating key result for goal ID: {GoalId}, Name: {KeyResultName}", goalId, createKeyResultRequest.Name);
             var endpoint = $"goal/{goalId}/key_result";
             var responseWrapper = await _apiConnection.PostAsync<CreateKeyResultRequest, CreateKeyResultResponse>(endpoint, createKeyResultRequest, cancellationToken);
             if (responseWrapper?.KeyResult == null)
@@ -144,6 +155,7 @@ namespace ClickUp.Api.Client.Services
             EditKeyResultRequest editKeyResultRequest,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Editing key result ID: {KeyResultId}", keyResultId);
             var endpoint = $"key_result/{keyResultId}";
             var responseWrapper = await _apiConnection.PutAsync<EditKeyResultRequest, EditKeyResultResponse>(endpoint, editKeyResultRequest, cancellationToken);
             if (responseWrapper?.KeyResult == null)
@@ -158,6 +170,7 @@ namespace ClickUp.Api.Client.Services
             string keyResultId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Deleting key result ID: {KeyResultId}", keyResultId);
             var endpoint = $"key_result/{keyResultId}";
             await _apiConnection.DeleteAsync(endpoint, cancellationToken);
         }

--- a/src/ClickUp.Api.Client/Services/GuestsService.cs
+++ b/src/ClickUp.Api.Client/Services/GuestsService.cs
@@ -11,6 +11,8 @@ using ClickUp.Api.Client.Models.Entities;
 using ClickUp.Api.Client.Models.Entities.Users;
 using ClickUp.Api.Client.Models.RequestModels.Guests;
 using ClickUp.Api.Client.Models.ResponseModels.Guests; // Assuming GetGuestResponse etc.
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ClickUp.Api.Client.Services
 {
@@ -20,15 +22,18 @@ namespace ClickUp.Api.Client.Services
     public class GuestsService : IGuestsService
     {
         private readonly IApiConnection _apiConnection;
+        private readonly ILogger<GuestsService> _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GuestsService"/> class.
         /// </summary>
         /// <param name="apiConnection">The API connection to use for making requests.</param>
-        /// <exception cref="ArgumentNullException">Thrown if apiConnection is null.</exception>
-        public GuestsService(IApiConnection apiConnection)
+        /// <param name="logger">The logger for this service.</param>
+        /// <exception cref="ArgumentNullException">Thrown if apiConnection or logger is null.</exception>
+        public GuestsService(IApiConnection apiConnection, ILogger<GuestsService> logger)
         {
             _apiConnection = apiConnection ?? throw new ArgumentNullException(nameof(apiConnection));
+            _logger = logger ?? NullLogger<GuestsService>.Instance;
         }
 
         private string BuildQueryString(Dictionary<string, string?> queryParams)
@@ -56,6 +61,7 @@ namespace ClickUp.Api.Client.Services
             InviteGuestToWorkspaceRequest inviteGuestRequest,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Inviting guest to workspace ID: {WorkspaceId}, Email: {GuestEmail}", workspaceId, inviteGuestRequest.Email);
             var endpoint = $"team/{workspaceId}/guest"; // team_id is workspaceId
             var response = await _apiConnection.PostAsync<InviteGuestToWorkspaceRequest, InviteGuestToWorkspaceResponse>(endpoint, inviteGuestRequest, cancellationToken);
             if (response == null)
@@ -75,6 +81,7 @@ namespace ClickUp.Api.Client.Services
             string guestId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting guest ID: {GuestId} for workspace ID: {WorkspaceId}", guestId, workspaceId);
             var endpoint = $"team/{workspaceId}/guest/{guestId}";
             var response = await _apiConnection.GetAsync<GetGuestResponse>(endpoint, cancellationToken);
             if (response == null) // The interface expects GetGuestResponse, which wraps Guest.
@@ -95,6 +102,7 @@ namespace ClickUp.Api.Client.Services
             EditGuestOnWorkspaceRequest updateGuestRequest, // Changed from UpdateGuestRequest
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Editing guest ID: {GuestId} on workspace ID: {WorkspaceId}", guestId, workspaceId);
             var endpoint = $"team/{workspaceId}/guest/{guestId}";
             var responseWrapper = await _apiConnection.PutAsync<EditGuestOnWorkspaceRequest, GetGuestResponse>(endpoint, updateGuestRequest, cancellationToken);
             if (responseWrapper?.Guest == null)
@@ -110,6 +118,7 @@ namespace ClickUp.Api.Client.Services
             string guestId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Removing guest ID: {GuestId} from workspace ID: {WorkspaceId}", guestId, workspaceId);
             var endpoint = $"team/{workspaceId}/guest/{guestId}";
             // API returns a 'team' object, but for a DELETE, we often don't need it.
             await _apiConnection.DeleteAsync(endpoint, cancellationToken);
@@ -125,6 +134,7 @@ namespace ClickUp.Api.Client.Services
             string? teamId = null, // This is workspaceId for the task context
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Adding guest ID: {GuestId} to task ID: {TaskId}", guestId, taskId);
             var endpoint = $"task/{taskId}/guest/{guestId}";
             var queryParams = new Dictionary<string, string?>();
             if (includeShared.HasValue) queryParams["include_shared"] = includeShared.Value.ToString().ToLower();
@@ -149,6 +159,7 @@ namespace ClickUp.Api.Client.Services
             string? teamId = null, // This is workspaceId for the task context
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Removing guest ID: {GuestId} from task ID: {TaskId}", guestId, taskId);
             var endpoint = $"task/{taskId}/guest/{guestId}";
             var queryParams = new Dictionary<string, string?>();
             if (includeShared.HasValue) queryParams["include_shared"] = includeShared.Value.ToString().ToLower();
@@ -175,6 +186,7 @@ namespace ClickUp.Api.Client.Services
             bool? includeShared = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Adding guest ID: {GuestId} to list ID: {ListId}", guestId, listId);
             var endpoint = $"list/{listId}/guest/{guestId}";
             var queryParams = new Dictionary<string, string?>();
             if (includeShared.HasValue) queryParams["include_shared"] = includeShared.Value.ToString().ToLower();
@@ -195,6 +207,7 @@ namespace ClickUp.Api.Client.Services
             bool? includeShared = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Removing guest ID: {GuestId} from list ID: {ListId}", guestId, listId);
             var endpoint = $"list/{listId}/guest/{guestId}";
             var queryParams = new Dictionary<string, string?>();
             if (includeShared.HasValue) queryParams["include_shared"] = includeShared.Value.ToString().ToLower();
@@ -216,6 +229,7 @@ namespace ClickUp.Api.Client.Services
             bool? includeShared = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Adding guest ID: {GuestId} to folder ID: {FolderId}", guestId, folderId);
             var endpoint = $"folder/{folderId}/guest/{guestId}";
             var queryParams = new Dictionary<string, string?>();
             if (includeShared.HasValue) queryParams["include_shared"] = includeShared.Value.ToString().ToLower();
@@ -236,6 +250,7 @@ namespace ClickUp.Api.Client.Services
             bool? includeShared = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Removing guest ID: {GuestId} from folder ID: {FolderId}", guestId, folderId);
             var endpoint = $"folder/{folderId}/guest/{guestId}";
             var queryParams = new Dictionary<string, string?>();
             if (includeShared.HasValue) queryParams["include_shared"] = includeShared.Value.ToString().ToLower();

--- a/src/ClickUp.Api.Client/Services/MembersService.cs
+++ b/src/ClickUp.Api.Client/Services/MembersService.cs
@@ -7,6 +7,8 @@ using ClickUp.Api.Client.Abstractions.Http; // IApiConnection
 using ClickUp.Api.Client.Abstractions.Services;
 using ClickUp.Api.Client.Models.Entities;
 using ClickUp.Api.Client.Models.ResponseModels.Members; // Assuming GetMembersResponse exists
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ClickUp.Api.Client.Services
 {
@@ -16,15 +18,18 @@ namespace ClickUp.Api.Client.Services
     public class MembersService : IMembersService
     {
         private readonly IApiConnection _apiConnection;
+        private readonly ILogger<MembersService> _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MembersService"/> class.
         /// </summary>
         /// <param name="apiConnection">The API connection to use for making requests.</param>
-        /// <exception cref="ArgumentNullException">Thrown if apiConnection is null.</exception>
-        public MembersService(IApiConnection apiConnection)
+        /// <param name="logger">The logger for this service.</param>
+        /// <exception cref="ArgumentNullException">Thrown if apiConnection or logger is null.</exception>
+        public MembersService(IApiConnection apiConnection, ILogger<MembersService> logger)
         {
             _apiConnection = apiConnection ?? throw new ArgumentNullException(nameof(apiConnection));
+            _logger = logger ?? NullLogger<MembersService>.Instance;
         }
 
         /// <inheritdoc />
@@ -32,6 +37,7 @@ namespace ClickUp.Api.Client.Services
             string taskId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting task members for task ID: {TaskId}", taskId);
             var endpoint = $"task/{taskId}/member";
             var response = await _apiConnection.GetAsync<GetMembersResponse>(endpoint, cancellationToken); // API returns {"members": [...]}
             return response?.Members ?? Enumerable.Empty<ClickUp.Api.Client.Models.ResponseModels.Members.Member>();
@@ -42,6 +48,7 @@ namespace ClickUp.Api.Client.Services
             string listId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting list members for list ID: {ListId}", listId);
             var endpoint = $"list/{listId}/member";
             var response = await _apiConnection.GetAsync<GetMembersResponse>(endpoint, cancellationToken); // API returns {"members": [...]}
             return response?.Members ?? Enumerable.Empty<ClickUp.Api.Client.Models.ResponseModels.Members.Member>();

--- a/src/ClickUp.Api.Client/Services/RolesService.cs
+++ b/src/ClickUp.Api.Client/Services/RolesService.cs
@@ -9,6 +9,8 @@ using ClickUp.Api.Client.Abstractions.Http; // IApiConnection
 using ClickUp.Api.Client.Abstractions.Services;
 using ClickUp.Api.Client.Models.Entities;
 using ClickUp.Api.Client.Models.ResponseModels.Roles; // Assuming GetCustomRolesResponse exists
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ClickUp.Api.Client.Services
 {
@@ -18,15 +20,18 @@ namespace ClickUp.Api.Client.Services
     public class RolesService : IRolesService
     {
         private readonly IApiConnection _apiConnection;
+        private readonly ILogger<RolesService> _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesService"/> class.
         /// </summary>
         /// <param name="apiConnection">The API connection to use for making requests.</param>
-        /// <exception cref="ArgumentNullException">Thrown if apiConnection is null.</exception>
-        public RolesService(IApiConnection apiConnection)
+        /// <param name="logger">The logger for this service.</param>
+        /// <exception cref="ArgumentNullException">Thrown if apiConnection or logger is null.</exception>
+        public RolesService(IApiConnection apiConnection, ILogger<RolesService> logger)
         {
             _apiConnection = apiConnection ?? throw new ArgumentNullException(nameof(apiConnection));
+            _logger = logger ?? NullLogger<RolesService>.Instance;
         }
 
         private string BuildQueryString(Dictionary<string, string?> queryParams)
@@ -54,6 +59,7 @@ namespace ClickUp.Api.Client.Services
             bool? includeMembers = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting custom roles for workspace ID: {WorkspaceId}, IncludeMembers: {IncludeMembers}", workspaceId, includeMembers);
             var endpoint = $"team/{workspaceId}/customroles"; // team_id is workspaceId
             var queryParams = new Dictionary<string, string?>();
             if (includeMembers.HasValue) queryParams["include_members"] = includeMembers.Value.ToString().ToLower();

--- a/src/ClickUp.Api.Client/Services/SharedHierarchyService.cs
+++ b/src/ClickUp.Api.Client/Services/SharedHierarchyService.cs
@@ -6,6 +6,8 @@ using ClickUp.Api.Client.Abstractions.Http; // IApiConnection
 using ClickUp.Api.Client.Abstractions.Services;
 // using ClickUp.Api.Client.Models.ResponseModels; // No longer needed directly here
 using ClickUp.Api.Client.Models.ResponseModels.Sharing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ClickUp.Api.Client.Services
 {
@@ -15,15 +17,18 @@ namespace ClickUp.Api.Client.Services
     public class SharedHierarchyService : ISharedHierarchyService
     {
         private readonly IApiConnection _apiConnection;
+        private readonly ILogger<SharedHierarchyService> _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SharedHierarchyService"/> class.
         /// </summary>
         /// <param name="apiConnection">The API connection to use for making requests.</param>
-        /// <exception cref="ArgumentNullException">Thrown if apiConnection is null.</exception>
-        public SharedHierarchyService(IApiConnection apiConnection)
+        /// <param name="logger">The logger for this service.</param>
+        /// <exception cref="ArgumentNullException">Thrown if apiConnection or logger is null.</exception>
+        public SharedHierarchyService(IApiConnection apiConnection, ILogger<SharedHierarchyService> logger)
         {
             _apiConnection = apiConnection ?? throw new ArgumentNullException(nameof(apiConnection));
+            _logger = logger ?? NullLogger<SharedHierarchyService>.Instance;
         }
 
         /// <inheritdoc />
@@ -31,6 +36,7 @@ namespace ClickUp.Api.Client.Services
             string workspaceId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting shared hierarchy for workspace ID: {WorkspaceId}", workspaceId);
             var endpoint = $"team/{workspaceId}/shared"; // team_id is workspaceId
             var response = await _apiConnection.GetAsync<SharedHierarchyResponse>(endpoint, cancellationToken);
             return response ?? throw new InvalidOperationException("API returned null response for SharedHierarchy.");

--- a/src/ClickUp.Api.Client/Services/SpacesService.cs
+++ b/src/ClickUp.Api.Client/Services/SpacesService.cs
@@ -11,6 +11,8 @@ using ClickUp.Api.Client.Models.Entities;
 using ClickUp.Api.Client.Models.Entities.Spaces;
 using ClickUp.Api.Client.Models.RequestModels.Spaces;
 using ClickUp.Api.Client.Models.ResponseModels.Spaces; // Assuming GetSpacesResponse exists
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ClickUp.Api.Client.Services
 {
@@ -20,15 +22,18 @@ namespace ClickUp.Api.Client.Services
     public class SpacesService : ISpacesService
     {
         private readonly IApiConnection _apiConnection;
+        private readonly ILogger<SpacesService> _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SpacesService"/> class.
         /// </summary>
         /// <param name="apiConnection">The API connection to use for making requests.</param>
-        /// <exception cref="ArgumentNullException">Thrown if apiConnection is null.</exception>
-        public SpacesService(IApiConnection apiConnection)
+        /// <param name="logger">The logger for this service.</param>
+        /// <exception cref="ArgumentNullException">Thrown if apiConnection or logger is null.</exception>
+        public SpacesService(IApiConnection apiConnection, ILogger<SpacesService> logger)
         {
             _apiConnection = apiConnection ?? throw new ArgumentNullException(nameof(apiConnection));
+            _logger = logger ?? NullLogger<SpacesService>.Instance;
         }
 
         private string BuildQueryString(Dictionary<string, string?> queryParams)
@@ -56,6 +61,7 @@ namespace ClickUp.Api.Client.Services
             bool? archived = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting spaces for workspace ID: {WorkspaceId}, Archived: {Archived}", workspaceId, archived);
             var endpoint = $"team/{workspaceId}/space"; // team_id is workspaceId
             var queryParams = new Dictionary<string, string?>();
             if (archived.HasValue) queryParams["archived"] = archived.Value.ToString().ToLower();
@@ -71,6 +77,7 @@ namespace ClickUp.Api.Client.Services
             CreateSpaceRequest createSpaceRequest,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Creating space in workspace ID: {WorkspaceId}, Name: {SpaceName}", workspaceId, createSpaceRequest.Name);
             var endpoint = $"team/{workspaceId}/space";
             var space = await _apiConnection.PostAsync<CreateSpaceRequest, Space>(endpoint, createSpaceRequest, cancellationToken);
             if (space == null)
@@ -85,6 +92,7 @@ namespace ClickUp.Api.Client.Services
             string spaceId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting space ID: {SpaceId}", spaceId);
             var endpoint = $"space/{spaceId}";
             var space = await _apiConnection.GetAsync<Space>(endpoint, cancellationToken);
             if (space == null)
@@ -100,6 +108,7 @@ namespace ClickUp.Api.Client.Services
             UpdateSpaceRequest updateSpaceRequest,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Updating space ID: {SpaceId}, Name: {SpaceName}", spaceId, updateSpaceRequest.Name);
             var endpoint = $"space/{spaceId}";
             var space = await _apiConnection.PutAsync<UpdateSpaceRequest, Space>(endpoint, updateSpaceRequest, cancellationToken);
             if (space == null)
@@ -114,6 +123,7 @@ namespace ClickUp.Api.Client.Services
             string spaceId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Deleting space ID: {SpaceId}", spaceId);
             var endpoint = $"space/{spaceId}";
             await _apiConnection.DeleteAsync(endpoint, cancellationToken);
         }

--- a/src/ClickUp.Api.Client/Services/TaskRelationshipsService.cs
+++ b/src/ClickUp.Api.Client/Services/TaskRelationshipsService.cs
@@ -13,6 +13,8 @@ using ClickUp.Api.Client.Models.RequestModels.TaskRelationships; // AddDependenc
 // using ClickUp.Api.Client.Models.RequestModels.Tasks; // Not needed if AddDependencyRequest is in its own namespace
 using ClickUp.Api.Client.Models.ResponseModels;
 using ClickUp.Api.Client.Models.ResponseModels.Tasks; // For GetTaskResponse
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ClickUp.Api.Client.Services
 {
@@ -22,15 +24,18 @@ namespace ClickUp.Api.Client.Services
     public class TaskRelationshipsService : ITaskRelationshipsService
     {
         private readonly IApiConnection _apiConnection;
+        private readonly ILogger<TaskRelationshipsService> _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TaskRelationshipsService"/> class.
         /// </summary>
         /// <param name="apiConnection">The API connection to use for making requests.</param>
-        /// <exception cref="ArgumentNullException">Thrown if apiConnection is null.</exception>
-        public TaskRelationshipsService(IApiConnection apiConnection)
+        /// <param name="logger">The logger for this service.</param>
+        /// <exception cref="ArgumentNullException">Thrown if apiConnection or logger is null.</exception>
+        public TaskRelationshipsService(IApiConnection apiConnection, ILogger<TaskRelationshipsService> logger)
         {
             _apiConnection = apiConnection ?? throw new ArgumentNullException(nameof(apiConnection));
+            _logger = logger ?? NullLogger<TaskRelationshipsService>.Instance;
         }
 
         private string BuildQueryString(Dictionary<string, string?> queryParams)
@@ -61,6 +66,7 @@ namespace ClickUp.Api.Client.Services
             string? teamId = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Adding dependency for task ID: {TaskId}, DependsOn: {DependsOn}, DependencyOf: {DependencyOf}", taskId, dependsOnTaskId, dependencyOfTaskId);
             if (string.IsNullOrWhiteSpace(dependsOnTaskId) && string.IsNullOrWhiteSpace(dependencyOfTaskId))
             {
                 throw new ArgumentException("Either dependsOnTaskId or dependencyOfTaskId must be provided.");
@@ -91,6 +97,7 @@ namespace ClickUp.Api.Client.Services
             string? teamId = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Deleting dependency for task ID: {TaskId}, DependsOn: {DependsOn}, DependencyOf: {DependencyOf}", taskId, dependsOn, dependencyOf);
             // Per API docs, DELETE /v2/task/{task_id}/dependency uses query parameters:
             // depends_on (task_id) OR dependency_of (task_id)
             // The interface signature is (string taskId, string dependsOn, string dependencyOf, ...)
@@ -128,6 +135,7 @@ namespace ClickUp.Api.Client.Services
             string? teamId = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Adding task link from task ID: {TaskId} to task ID: {LinksToTaskId}", taskId, linksToTaskId);
             var endpoint = $"task/{taskId}/link/{linksToTaskId}";
             var queryParams = new Dictionary<string, string?>();
             if (customTaskIds.HasValue) queryParams["custom_task_ids"] = customTaskIds.Value.ToString().ToLower();
@@ -148,6 +156,7 @@ namespace ClickUp.Api.Client.Services
             string? teamId = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Deleting task link from task ID: {TaskId} to task ID: {LinksToTaskId}", taskId, linksToTaskId);
             var endpoint = $"task/{taskId}/link/{linksToTaskId}";
             var queryParams = new Dictionary<string, string?>();
             if (customTaskIds.HasValue) queryParams["custom_task_ids"] = customTaskIds.Value.ToString().ToLower();

--- a/src/ClickUp.Api.Client/Services/TemplatesService.cs
+++ b/src/ClickUp.Api.Client/Services/TemplatesService.cs
@@ -10,6 +10,8 @@ using ClickUp.Api.Client.Abstractions.Services;
 using ClickUp.Api.Client.Models.Entities.Templates; // For TaskTemplate if it were used directly
 using ClickUp.Api.Client.Models.ResponseModels.Templates;
 using System.Linq; // For Enumerable.Empty, though not directly used here but good for consistency
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ClickUp.Api.Client.Services
 {
@@ -19,15 +21,18 @@ namespace ClickUp.Api.Client.Services
     public class TemplatesService : ITemplatesService
     {
         private readonly IApiConnection _apiConnection;
+        private readonly ILogger<TemplatesService> _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TemplatesService"/> class.
         /// </summary>
         /// <param name="apiConnection">The API connection to use for making requests.</param>
-        /// <exception cref="ArgumentNullException">Thrown if apiConnection is null.</exception>
-        public TemplatesService(IApiConnection apiConnection)
+        /// <param name="logger">The logger for this service.</param>
+        /// <exception cref="ArgumentNullException">Thrown if apiConnection or logger is null.</exception>
+        public TemplatesService(IApiConnection apiConnection, ILogger<TemplatesService> logger)
         {
             _apiConnection = apiConnection ?? throw new ArgumentNullException(nameof(apiConnection));
+            _logger = logger ?? NullLogger<TemplatesService>.Instance;
         }
 
         private string BuildQueryString(Dictionary<string, string?> queryParams)
@@ -55,6 +60,7 @@ namespace ClickUp.Api.Client.Services
             int page,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting task templates for workspace ID: {WorkspaceId}, Page: {Page}", workspaceId, page);
             var endpoint = $"team/{workspaceId}/taskTemplate"; // team_id is workspaceId
             var queryParams = new Dictionary<string, string?>
             {

--- a/src/ClickUp.Api.Client/Services/UserGroupService.cs
+++ b/src/ClickUp.Api.Client/Services/UserGroupService.cs
@@ -10,6 +10,8 @@ using ClickUp.Api.Client.Abstractions.Services;
 using ClickUp.Api.Client.Models.Entities.UserGroups;
 using ClickUp.Api.Client.Models.RequestModels.UserGroups;
 using ClickUp.Api.Client.Models.ResponseModels.UserGroups; // For GetUserGroupsResponse
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ClickUp.Api.Client.Services
 {
@@ -19,15 +21,18 @@ namespace ClickUp.Api.Client.Services
     public class UserGroupsService : IUserGroupsService
     {
         private readonly IApiConnection _apiConnection;
+        private readonly ILogger<UserGroupsService> _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UserGroupsService"/> class.
         /// </summary>
         /// <param name="apiConnection">The API connection to use for making requests.</param>
-        /// <exception cref="ArgumentNullException">Thrown if apiConnection is null.</exception>
-        public UserGroupsService(IApiConnection apiConnection)
+        /// <param name="logger">The logger for this service.</param>
+        /// <exception cref="ArgumentNullException">Thrown if apiConnection or logger is null.</exception>
+        public UserGroupsService(IApiConnection apiConnection, ILogger<UserGroupsService> logger)
         {
             _apiConnection = apiConnection ?? throw new ArgumentNullException(nameof(apiConnection));
+            _logger = logger ?? NullLogger<UserGroupsService>.Instance;
         }
 
         private string BuildQueryString(Dictionary<string, string?> queryParams)
@@ -55,6 +60,7 @@ namespace ClickUp.Api.Client.Services
             List<string>? groupIds = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting user groups for workspace ID: {WorkspaceId}, Group IDs: {GroupIds}", workspaceId, groupIds != null ? string.Join(",", groupIds) : "All");
             var endpoint = $"team/{workspaceId}/group";
             var queryParams = new Dictionary<string, string?>();
             if (groupIds != null && groupIds.Any())
@@ -73,6 +79,7 @@ namespace ClickUp.Api.Client.Services
             CreateUserGroupRequest request,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Creating user group in workspace ID: {WorkspaceId}, Name: {GroupName}", workspaceId, request.Name);
             var endpoint = $"team/{workspaceId}/group";
             // The API for Create Group (POST /team/{team_id}/group) returns the created UserGroup object directly.
             var userGroup = await _apiConnection.PostAsync<CreateUserGroupRequest, UserGroup>(endpoint, request, cancellationToken);
@@ -89,6 +96,7 @@ namespace ClickUp.Api.Client.Services
             UpdateUserGroupRequest request,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Updating user group ID: {GroupId}, Name: {GroupName}", groupId, request.Name);
             var endpoint = $"group/{groupId}";
             // The API for Update Group (PUT /group/{group_id}) returns the updated UserGroup object directly.
             var userGroup = await _apiConnection.PutAsync<UpdateUserGroupRequest, UserGroup>(endpoint, request, cancellationToken);
@@ -104,6 +112,7 @@ namespace ClickUp.Api.Client.Services
             string groupId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Deleting user group ID: {GroupId}", groupId);
             var endpoint = $"group/{groupId}";
             // API returns an empty JSON object {} on success.
             await _apiConnection.DeleteAsync(endpoint, cancellationToken);

--- a/src/ClickUp.Api.Client/Services/UsersService.cs
+++ b/src/ClickUp.Api.Client/Services/UsersService.cs
@@ -12,6 +12,8 @@ using System.Net.Http;
 using System.Text; // For StringBuilder
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ClickUp.Api.Client.Services
 {
@@ -21,16 +23,19 @@ namespace ClickUp.Api.Client.Services
     public class UsersService : IUsersService
     {
         private readonly IApiConnection _apiConnection;
+        private readonly ILogger<UsersService> _logger;
         private const string BaseWorkspaceEndpoint = "team"; // ClickUp v2 uses "team/{team_id}" for workspace context
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UsersService"/> class.
         /// </summary>
         /// <param name="apiConnection">The API connection to use for making requests.</param>
-        /// <exception cref="ArgumentNullException">Thrown if apiConnection is null.</exception>
-        public UsersService(IApiConnection apiConnection)
+        /// <param name="logger">The logger for this service.</param>
+        /// <exception cref="ArgumentNullException">Thrown if apiConnection or logger is null.</exception>
+        public UsersService(IApiConnection apiConnection, ILogger<UsersService> logger)
         {
             _apiConnection = apiConnection ?? throw new ArgumentNullException(nameof(apiConnection));
+            _logger = logger ?? NullLogger<UsersService>.Instance;
         }
 
         private string BuildQueryString(Dictionary<string, string?> queryParams)
@@ -59,6 +64,7 @@ namespace ClickUp.Api.Client.Services
             bool? includeShared = null,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting user ID: {UserId} from workspace ID: {WorkspaceId}", userId, workspaceId);
             var endpoint = $"{BaseWorkspaceEndpoint}/{workspaceId}/user/{userId}";
             var queryParams = new Dictionary<string, string?>();
             // 'includeShared' is not used as it's not standard for this endpoint.
@@ -106,6 +112,7 @@ namespace ClickUp.Api.Client.Services
             EditUserOnWorkspaceRequest editUserRequest,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Editing user ID: {UserId} on workspace ID: {WorkspaceId}", userId, workspaceId);
             var endpoint = $"{BaseWorkspaceEndpoint}/{workspaceId}/user/{userId}";
             var response = await _apiConnection.PutAsync<EditUserOnWorkspaceRequest, GetUserResponse>(endpoint, editUserRequest, cancellationToken);
 
@@ -132,6 +139,7 @@ namespace ClickUp.Api.Client.Services
             string userId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Removing user ID: {UserId} from workspace ID: {WorkspaceId}", userId, workspaceId);
             var endpoint = $"{BaseWorkspaceEndpoint}/{workspaceId}/user/{userId}";
             await _apiConnection.DeleteAsync(endpoint, cancellationToken);
         }

--- a/src/ClickUp.Api.Client/Services/ViewsService.cs
+++ b/src/ClickUp.Api.Client/Services/ViewsService.cs
@@ -11,6 +11,8 @@ using ClickUp.Api.Client.Models.Entities;
 using ClickUp.Api.Client.Models.Entities.Views; // View, CuTask DTOs
 using ClickUp.Api.Client.Models.RequestModels.Views;
 using ClickUp.Api.Client.Models.ResponseModels.Views; // GetViewTasksResponse and potential GetViewsResponse, GetViewResponse
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ClickUp.Api.Client.Services
 {
@@ -20,15 +22,18 @@ namespace ClickUp.Api.Client.Services
     public class ViewsService : IViewsService
     {
         private readonly IApiConnection _apiConnection;
+        private readonly ILogger<ViewsService> _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ViewsService"/> class.
         /// </summary>
         /// <param name="apiConnection">The API connection to use for making requests.</param>
-        /// <exception cref="ArgumentNullException">Thrown if apiConnection is null.</exception>
-        public ViewsService(IApiConnection apiConnection)
+        /// <param name="logger">The logger for this service.</param>
+        /// <exception cref="ArgumentNullException">Thrown if apiConnection or logger is null.</exception>
+        public ViewsService(IApiConnection apiConnection, ILogger<ViewsService> logger)
         {
             _apiConnection = apiConnection ?? throw new ArgumentNullException(nameof(apiConnection));
+            _logger = logger ?? NullLogger<ViewsService>.Instance;
         }
 
         private string BuildQueryString(Dictionary<string, string?> queryParams)
@@ -55,6 +60,7 @@ namespace ClickUp.Api.Client.Services
             string workspaceId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting workspace views for workspace ID: {WorkspaceId}", workspaceId);
             var endpoint = $"team/{workspaceId}/view"; // team_id is workspaceId
             var response = await _apiConnection.GetAsync<GetViewsResponse>(endpoint, cancellationToken);
             return response ?? throw new InvalidOperationException($"API response was null for GetWorkspaceViewsAsync (Workspace ID: {workspaceId}).");
@@ -66,6 +72,7 @@ namespace ClickUp.Api.Client.Services
             CreateViewRequest createViewRequest,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Creating workspace view in workspace ID: {WorkspaceId}, Name: {ViewName}", workspaceId, createViewRequest.Name);
             var endpoint = $"team/{workspaceId}/view";
             // Assuming CreateTeamViewResponse is the correct wrapper, or if it's just View, adjust PostAsync generic type
             var response = await _apiConnection.PostAsync<CreateViewRequest, CreateTeamViewResponse>(endpoint, createViewRequest, cancellationToken);
@@ -77,6 +84,7 @@ namespace ClickUp.Api.Client.Services
             string spaceId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting space views for space ID: {SpaceId}", spaceId);
             var endpoint = $"space/{spaceId}/view";
             var response = await _apiConnection.GetAsync<GetViewsResponse>(endpoint, cancellationToken);
             return response ?? throw new InvalidOperationException($"API response was null for GetSpaceViewsAsync (Space ID: {spaceId}).");
@@ -88,6 +96,7 @@ namespace ClickUp.Api.Client.Services
             CreateViewRequest createViewRequest,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Creating space view in space ID: {SpaceId}, Name: {ViewName}", spaceId, createViewRequest.Name);
             var endpoint = $"space/{spaceId}/view";
             var response = await _apiConnection.PostAsync<CreateViewRequest, CreateSpaceViewResponse>(endpoint, createViewRequest, cancellationToken);
             return response ?? throw new InvalidOperationException($"API response was null for CreateSpaceViewAsync (Space ID: {spaceId}).");
@@ -98,6 +107,7 @@ namespace ClickUp.Api.Client.Services
             string folderId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting folder views for folder ID: {FolderId}", folderId);
             var endpoint = $"folder/{folderId}/view";
             var response = await _apiConnection.GetAsync<GetViewsResponse>(endpoint, cancellationToken);
             return response ?? throw new InvalidOperationException($"API response was null for GetFolderViewsAsync (Folder ID: {folderId}).");
@@ -109,6 +119,7 @@ namespace ClickUp.Api.Client.Services
             CreateViewRequest createViewRequest,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Creating folder view in folder ID: {FolderId}, Name: {ViewName}", folderId, createViewRequest.Name);
             var endpoint = $"folder/{folderId}/view";
             var response = await _apiConnection.PostAsync<CreateViewRequest, CreateFolderViewResponse>(endpoint, createViewRequest, cancellationToken);
             return response ?? throw new InvalidOperationException($"API response was null for CreateFolderViewAsync (Folder ID: {folderId}).");
@@ -119,6 +130,7 @@ namespace ClickUp.Api.Client.Services
             string listId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting list views for list ID: {ListId}", listId);
             var endpoint = $"list/{listId}/view";
             var response = await _apiConnection.GetAsync<GetViewsResponse>(endpoint, cancellationToken);
             return response ?? throw new InvalidOperationException($"API response was null for GetListViewsAsync (List ID: {listId}).");
@@ -130,6 +142,7 @@ namespace ClickUp.Api.Client.Services
             CreateViewRequest createViewRequest,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Creating list view in list ID: {ListId}, Name: {ViewName}", listId, createViewRequest.Name);
             var endpoint = $"list/{listId}/view";
             var response = await _apiConnection.PostAsync<CreateViewRequest, CreateListViewResponse>(endpoint, createViewRequest, cancellationToken);
             return response ?? throw new InvalidOperationException($"API response was null for CreateListViewAsync (List ID: {listId}).");
@@ -140,6 +153,7 @@ namespace ClickUp.Api.Client.Services
             string viewId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting view ID: {ViewId}", viewId);
             var endpoint = $"view/{viewId}";
             var response = await _apiConnection.GetAsync<GetViewResponse>(endpoint, cancellationToken);
             return response ?? throw new InvalidOperationException($"API response was null for GetViewAsync (View ID: {viewId}).");
@@ -151,6 +165,7 @@ namespace ClickUp.Api.Client.Services
             UpdateViewRequest updateViewRequest,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Updating view ID: {ViewId}, Name: {ViewName}", viewId, updateViewRequest.Name);
             var endpoint = $"view/{viewId}";
             var response = await _apiConnection.PutAsync<UpdateViewRequest, UpdateViewResponse>(endpoint, updateViewRequest, cancellationToken);
             return response ?? throw new InvalidOperationException($"API response was null for UpdateViewAsync (View ID: {viewId}).");
@@ -161,6 +176,7 @@ namespace ClickUp.Api.Client.Services
             string viewId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Deleting view ID: {ViewId}", viewId);
             var endpoint = $"view/{viewId}";
             await _apiConnection.DeleteAsync(endpoint, cancellationToken);
         }
@@ -171,6 +187,7 @@ namespace ClickUp.Api.Client.Services
             int page,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting view tasks for view ID: {ViewId}, Page: {Page}", viewId, page);
             var endpoint = $"view/{viewId}/task";
             var queryParams = new Dictionary<string, string?>
             {

--- a/src/ClickUp.Api.Client/Services/WorkspacesService.cs
+++ b/src/ClickUp.Api.Client/Services/WorkspacesService.cs
@@ -6,6 +6,8 @@ using ClickUp.Api.Client.Abstractions.Http; // IApiConnection
 using ClickUp.Api.Client.Abstractions.Services;
 using ClickUp.Api.Client.Models.ResponseModels.Workspaces;
 // Potentially ClickUp.Api.Client.Models.Entities if Workspace, UserGroup etc. were directly used.
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace ClickUp.Api.Client.Services
 {
@@ -15,16 +17,19 @@ namespace ClickUp.Api.Client.Services
     public class WorkspacesService : IWorkspacesService
     {
         private readonly IApiConnection _apiConnection;
+        private readonly ILogger<WorkspacesService> _logger;
         private const string BaseWorkspaceEndpoint = "team"; // ClickUp v2 uses "team/{team_id}" for workspace context
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WorkspacesService"/> class.
         /// </summary>
         /// <param name="apiConnection">The API connection to use for making requests.</param>
-        /// <exception cref="ArgumentNullException">Thrown if apiConnection is null.</exception>
-        public WorkspacesService(IApiConnection apiConnection)
+        /// <param name="logger">The logger for this service.</param>
+        /// <exception cref="ArgumentNullException">Thrown if apiConnection or logger is null.</exception>
+        public WorkspacesService(IApiConnection apiConnection, ILogger<WorkspacesService> logger)
         {
             _apiConnection = apiConnection ?? throw new ArgumentNullException(nameof(apiConnection));
+            _logger = logger ?? NullLogger<WorkspacesService>.Instance;
         }
 
         /// <inheritdoc />
@@ -32,6 +37,7 @@ namespace ClickUp.Api.Client.Services
             string workspaceId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting workspace seats for workspace ID: {WorkspaceId}", workspaceId);
             // Endpoint: GET /api/v2/team/{team_id}/seats
             var endpoint = $"{BaseWorkspaceEndpoint}/{workspaceId}/seats";
             var response = await _apiConnection.GetAsync<GetWorkspaceSeatsResponse>(endpoint, cancellationToken);
@@ -47,6 +53,7 @@ namespace ClickUp.Api.Client.Services
             string workspaceId,
             CancellationToken cancellationToken = default)
         {
+            _logger.LogInformation("Getting workspace plan for workspace ID: {WorkspaceId}", workspaceId);
             // Endpoint: GET /api/v2/team/{team_id}/plan
             var endpoint = $"{BaseWorkspaceEndpoint}/{workspaceId}/plan";
             var response = await _apiConnection.GetAsync<GetWorkspacePlanResponse>(endpoint, cancellationToken);


### PR DESCRIPTION
Ensured all service classes in `src/ClickUp.Api.Client/Services/` consistently use `ILogger<T>` for logging.

- Added constructor injection for `ILogger<T>` where missing.
- Added basic logging statements (e.g., method entry) to public methods in the updated services.
- Verified that services already using `ILogger` followed a similar pattern.