### PR TITLE
feat(tests): Add unit tests for DTOs and AuthHandler

### DIFF
--- a/docs/plans/updatedPlans/ConsolidatedPlan.md
+++ b/docs/plans/updatedPlans/ConsolidatedPlan.md
@@ -37,11 +37,11 @@ This plan consolidates uncompleted items from the 11 detailed plan documents in 
 ## Phase 2: Testing Expansion
 
 ### 4. Expand Unit Test Coverage - Models & Helpers
-- [ ] **Task:** Write unit tests for polymorphic DTOs if any are identified as needing specific testing beyond standard deserialization.
+- [x] **Task:** Write unit tests for polymorphic DTOs if any are identified as needing specific testing beyond standard deserialization. (Completed for `CustomFieldValue`)
     - *Files:* New test files in `src/ClickUp.Api.Client.Tests/Models/`
     - *Why:* Ensures correct deserialization of complex model hierarchies.
     - *Ref:* `docs/plans/updatedPlans/testing/07-TestingStrategy.md`
-- [ ] **Task:** Write unit tests for `AuthenticationDelegatingHandler`.
+- [x] **Task:** Write unit tests for `AuthenticationDelegatingHandler`. (Tests added for current PAT implementation; OAuth and ClickUpClientOptions support to be added to handler later)
     - *Files:* New test file in `src/ClickUp.Api.Client.Tests/Http/`
     - *Why:* Verifies correct authentication header manipulation.
     - *Ref:* `docs/plans/updatedPlans/testing/07-TestingStrategy.md`

--- a/src/ClickUp.Api.Client.Tests/Http/AuthenticationDelegatingHandlerTests.cs
+++ b/src/ClickUp.Api.Client.Tests/Http/AuthenticationDelegatingHandlerTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using ClickUp.Api.Client.Http.Handlers;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace ClickUp.Api.Client.Tests.Http
+{
+    public class AuthenticationDelegatingHandlerTests
+    {
+        private const string DummyApiKey = "pk_test_api_key";
+
+        [Fact]
+        public void Constructor_WithValidApiKey_ShouldNotThrow()
+        {
+            var handler = new AuthenticationDelegatingHandler(DummyApiKey);
+            Assert.NotNull(handler);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void Constructor_WithInvalidApiKey_ShouldThrowArgumentNullException(string invalidApiKey)
+        {
+            Assert.Throws<ArgumentNullException>(() => new AuthenticationDelegatingHandler(invalidApiKey));
+        }
+
+        [Fact]
+        public async Task SendAsync_ShouldAddAuthorizationHeader_WithApiKey()
+        {
+            // Arrange
+            var handler = new AuthenticationDelegatingHandler(DummyApiKey);
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://api.clickup.com/api/v2/user");
+
+            var mockInnerHandler = new Mock<HttpMessageHandler>();
+            mockInnerHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage(System.Net.HttpStatusCode.OK))
+                .Verifiable();
+
+            handler.InnerHandler = mockInnerHandler.Object;
+
+            var invoker = new HttpMessageInvoker(handler);
+
+            // Act
+            await invoker.SendAsync(request, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(request.Headers.Authorization);
+            // Current implementation directly uses the API key as the scheme and parameter.
+            // The scheme should be the API key itself.
+            Assert.Equal(DummyApiKey, request.Headers.Authorization.Scheme);
+            Assert.Null(request.Headers.Authorization.Parameter); // Parameter is null when scheme itself is the token
+
+            mockInnerHandler.Protected().Verify(
+                "SendAsync",
+                Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(req => req == request),
+                ItExpr.IsAny<CancellationToken>()
+            );
+        }
+
+        [Fact]
+        public async Task SendAsync_ShouldCallInnerHandler()
+        {
+            // Arrange
+            var handler = new AuthenticationDelegatingHandler(DummyApiKey);
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://api.clickup.com/api/v2/user");
+            var expectedResponse = new HttpResponseMessage(System.Net.HttpStatusCode.OK);
+
+            var mockInnerHandler = new Mock<HttpMessageHandler>();
+            mockInnerHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(expectedResponse);
+
+            handler.InnerHandler = mockInnerHandler.Object;
+            var invoker = new HttpMessageInvoker(handler);
+
+            // Act
+            var response = await invoker.SendAsync(request, CancellationToken.None);
+
+            // Assert
+            Assert.Same(expectedResponse, response);
+            mockInnerHandler.Protected().Verify(
+                "SendAsync",
+                Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(req => req == request),
+                ItExpr.IsAny<CancellationToken>()
+            );
+        }
+    }
+}

--- a/src/ClickUp.Api.Client.Tests/Models/Entities/CustomFieldValueTests.cs
+++ b/src/ClickUp.Api.Client.Tests/Models/Entities/CustomFieldValueTests.cs
@@ -1,0 +1,251 @@
+using System.Text.Json;
+using ClickUp.Api.Client.Models.Entities;
+using ClickUp.Api.Client.Helpers; // For JsonSerializerOptionsHelper
+using Xunit;
+
+namespace ClickUp.Api.Client.Tests.Models.Entities
+{
+    public class CustomFieldValueTests
+    {
+        private readonly JsonSerializerOptions _jsonSerializerOptions = JsonSerializerOptionsHelper.Options;
+
+        [Fact]
+        public void Deserialize_TextFieldValue_Correctly()
+        {
+            var json = @"{
+                ""id"": ""03efda77-c7a0-42d3-8afd-fd546353c2f5"",
+                ""name"": ""Text Field"",
+                ""type"": ""text"",
+                ""type_config"": {},
+                ""date_created"": ""1566400407303"",
+                ""hide_from_guests"": false,
+                ""value"": ""This is some text""
+            }";
+
+            var customField = JsonSerializer.Deserialize<CustomFieldValue>(json, _jsonSerializerOptions);
+
+            Assert.NotNull(customField);
+            Assert.Equal("text", customField.Type);
+            Assert.IsType<JsonElement>(customField.Value);
+            var valueElement = (JsonElement)customField.Value;
+            Assert.Equal(JsonValueKind.String, valueElement.ValueKind);
+            Assert.Equal("This is some text", valueElement.GetString());
+        }
+
+        [Fact]
+        public void Deserialize_NumberFieldValue_Correctly()
+        {
+            var json = @"{
+                ""id"": ""123abcde-c7a0-42d3-8afd-fd546353c2f5"",
+                ""name"": ""Number Field"",
+                ""type"": ""number"",
+                ""type_config"": {},
+                ""date_created"": ""1566400407304"",
+                ""hide_from_guests"": false,
+                ""value"": 123.45
+            }";
+
+            var customField = JsonSerializer.Deserialize<CustomFieldValue>(json, _jsonSerializerOptions);
+
+            Assert.NotNull(customField);
+            Assert.Equal("number", customField.Type);
+            Assert.IsType<JsonElement>(customField.Value);
+            var valueElement = (JsonElement)customField.Value;
+            Assert.Equal(JsonValueKind.Number, valueElement.ValueKind);
+            Assert.Equal(123.45, valueElement.GetDouble());
+        }
+
+        [Fact]
+        public void Deserialize_DropdownFieldValue_Correctly()
+        {
+            // Dropdown 'value' stores the ID of the selected option, which is often a GUID (string) or an int.
+            // Assuming it's a string ID for this test.
+            var json = @"{
+                ""id"": ""abcdef12-c7a0-42d3-8afd-fd546353c2f5"",
+                ""name"": ""Dropdown Field"",
+                ""type"": ""drop_down"",
+                ""type_config"": { ""options"": [{""id"": ""opt_guid_1"", ""name"": ""Option 1""}] },
+                ""date_created"": ""1566400407305"",
+                ""hide_from_guests"": false,
+                ""value"": ""opt_guid_1""
+            }";
+
+            var customField = JsonSerializer.Deserialize<CustomFieldValue>(json, _jsonSerializerOptions);
+
+            Assert.NotNull(customField);
+            Assert.Equal("drop_down", customField.Type);
+            Assert.IsType<JsonElement>(customField.Value);
+            var valueElement = (JsonElement)customField.Value;
+            Assert.Equal(JsonValueKind.String, valueElement.ValueKind);
+            Assert.Equal("opt_guid_1", valueElement.GetString());
+        }
+
+        [Fact]
+        public void Deserialize_DropdownFieldValue_WithNumericValue_Correctly()
+        {
+            // For some dropdowns, the 'value' might be the numeric orderindex of the selected option.
+            var json = @"{
+                ""id"": ""abcdef12-c7a0-42d3-8afd-fd546353c2f5"",
+                ""name"": ""Dropdown Field"",
+                ""type"": ""drop_down"",
+                ""type_config"": { ""options"": [{""id"": ""opt_guid_1"", ""name"": ""Option 1"", ""orderindex"": 0}] },
+                ""date_created"": ""1566400407305"",
+                ""hide_from_guests"": false,
+                ""value"": 0
+            }";
+
+            var customField = JsonSerializer.Deserialize<CustomFieldValue>(json, _jsonSerializerOptions);
+
+            Assert.NotNull(customField);
+            Assert.Equal("drop_down", customField.Type);
+            Assert.IsType<JsonElement>(customField.Value);
+            var valueElement = (JsonElement)customField.Value;
+            Assert.Equal(JsonValueKind.Number, valueElement.ValueKind);
+            Assert.Equal(0, valueElement.GetInt32());
+        }
+
+        [Fact]
+        public void Deserialize_LabelsFieldValue_Correctly()
+        {
+            var json = @"{
+                ""id"": ""labels123-c7a0-42d3-8afd-fd546353c2f5"",
+                ""name"": ""Labels Field"",
+                ""type"": ""labels"",
+                ""type_config"": { ""options"": [{""id"": ""label_A"", ""label"": ""Label A""}] },
+                ""date_created"": ""1566400407306"",
+                ""hide_from_guests"": false,
+                ""value"": [""label_A""]
+            }";
+
+            var customField = JsonSerializer.Deserialize<CustomFieldValue>(json, _jsonSerializerOptions);
+
+            Assert.NotNull(customField);
+            Assert.Equal("labels", customField.Type);
+            Assert.IsType<JsonElement>(customField.Value);
+            var valueElement = (JsonElement)customField.Value;
+            Assert.Equal(JsonValueKind.Array, valueElement.ValueKind);
+            Assert.Equal(1, valueElement.GetArrayLength());
+            Assert.Equal("label_A", valueElement[0].GetString());
+        }
+
+        [Fact]
+        public void Deserialize_UsersFieldValue_Correctly()
+        {
+            // Value for 'users' type is an array of user IDs (integers)
+            var json = @"{
+                ""id"": ""users123-c7a0-42d3-8afd-fd546353c2f5"",
+                ""name"": ""Users Field"",
+                ""type"": ""users"",
+                ""type_config"": {},
+                ""date_created"": ""1566400407307"",
+                ""hide_from_guests"": false,
+                ""value"": [183, 184]
+            }";
+
+            var customField = JsonSerializer.Deserialize<CustomFieldValue>(json, _jsonSerializerOptions);
+
+            Assert.NotNull(customField);
+            Assert.Equal("users", customField.Type);
+            Assert.IsType<JsonElement>(customField.Value);
+            var valueElement = (JsonElement)customField.Value;
+            Assert.Equal(JsonValueKind.Array, valueElement.ValueKind);
+            Assert.Equal(2, valueElement.GetArrayLength());
+            Assert.Equal(183, valueElement[0].GetInt32());
+            Assert.Equal(184, valueElement[1].GetInt32());
+        }
+
+        [Fact]
+        public void Deserialize_DateFieldValue_Correctly()
+        {
+            // Date value is typically a Unix timestamp string
+            var json = @"{
+                ""id"": ""date123-c7a0-42d3-8afd-fd546353c2f5"",
+                ""name"": ""Date Field"",
+                ""type"": ""date"",
+                ""type_config"": {},
+                ""date_created"": ""1566400407308"",
+                ""hide_from_guests"": false,
+                ""value"": ""1667367645000""
+            }";
+
+            var customField = JsonSerializer.Deserialize<CustomFieldValue>(json, _jsonSerializerOptions);
+
+            Assert.NotNull(customField);
+            Assert.Equal("date", customField.Type);
+            Assert.IsType<JsonElement>(customField.Value);
+            var valueElement = (JsonElement)customField.Value;
+            Assert.Equal(JsonValueKind.String, valueElement.ValueKind);
+            Assert.Equal("1667367645000", valueElement.GetString());
+            // Further conversion to DateTimeOffset would be handled by the SDK user or a helper
+        }
+
+        [Fact]
+        public void Deserialize_CheckboxFieldValue_Correctly()
+        {
+            // Checkbox value is typically "0" or "1" as a string, or boolean true/false
+            var json = @"{
+                ""id"": ""checkbox123-c7a0-42d3-8afd-fd546353c2f5"",
+                ""name"": ""Checkbox Field"",
+                ""type"": ""checkbox"",
+                ""type_config"": {},
+                ""date_created"": ""1566400407309"",
+                ""hide_from_guests"": false,
+                ""value"": ""1""
+            }";
+
+            var customField = JsonSerializer.Deserialize<CustomFieldValue>(json, _jsonSerializerOptions);
+
+            Assert.NotNull(customField);
+            Assert.Equal("checkbox", customField.Type);
+            Assert.IsType<JsonElement>(customField.Value);
+            var valueElement = (JsonElement)customField.Value;
+            Assert.Equal(JsonValueKind.String, valueElement.ValueKind);
+            Assert.Equal("1", valueElement.GetString());
+
+            // Test with boolean true
+             json = @"{
+                ""id"": ""checkbox123-c7a0-42d3-8afd-fd546353c2f5"",
+                ""name"": ""Checkbox Field"",
+                ""type"": ""checkbox"",
+                ""type_config"": {},
+                ""date_created"": ""1566400407309"",
+                ""hide_from_guests"": false,
+                ""value"": true
+            }";
+            customField = JsonSerializer.Deserialize<CustomFieldValue>(json, _jsonSerializerOptions);
+            Assert.NotNull(customField);
+            valueElement = (JsonElement)customField.Value;
+            Assert.Equal(JsonValueKind.True, valueElement.ValueKind);
+            Assert.True(valueElement.GetBoolean());
+        }
+
+        [Fact]
+        public void Deserialize_LocationFieldValue_Correctly()
+        {
+            var json = @"{
+                ""id"": ""location123-abc"",
+                ""name"": ""Location Field"",
+                ""type"": ""location"",
+                ""type_config"": {},
+                ""date_created"": ""1566400407310"",
+                ""hide_from_guests"": false,
+                ""value"": {
+                    ""location"": { ""lat"": -28.016667, ""lng"": 153.4 },
+                    ""formatted_address"": ""Gold Coast QLD, Australia""
+                }
+            }";
+
+            var customField = JsonSerializer.Deserialize<CustomFieldValue>(json, _jsonSerializerOptions);
+            Assert.NotNull(customField);
+            Assert.Equal("location", customField.Type);
+            Assert.IsType<JsonElement>(customField.Value);
+            var valueElement = (JsonElement)customField.Value;
+            Assert.Equal(JsonValueKind.Object, valueElement.ValueKind);
+            Assert.True(valueElement.TryGetProperty("location", out var locObj));
+            Assert.True(locObj.TryGetProperty("lat", out var latVal));
+            Assert.Equal(-28.016667, latVal.GetDouble());
+            Assert.True(valueElement.TryGetProperty("formatted_address", out var addrVal));
+            Assert.Equal("Gold Coast QLD, Australia", addrVal.GetString());
+        }
+    }
+}


### PR DESCRIPTION
Adds unit tests for polymorphic DTO deserialization, focusing on CustomFieldValue. These tests verify that the 'Value' property of CustomFieldValue is correctly deserialized by System.Text.Json into appropriate JsonElement types for various custom field kinds (text, number, dropdown, labels, users, date, checkbox, location).

Also adds unit tests for the current implementation of AuthenticationDelegatingHandler. These tests cover:
- API key validation in the constructor.
- Correct formation of the Authorization header for Personal Access Tokens (current behavior where the token itself is the header value).
- Invocation of the inner handler.

A note has been made that AuthenticationDelegatingHandler tests will need to be expanded when the handler is updated to use ClickUpClientOptions and support OAuth token authentication.