### PR TITLE
Fix: Resolve build errors in UserGroup, Guests, and TimeTracking serv…

### DIFF
--- a/docs/plans/updatedPlans/ConsolidatedPlan.md
+++ b/docs/plans/updatedPlans/ConsolidatedPlan.md
@@ -58,7 +58,7 @@ This plan consolidates uncompleted items from the 11 detailed plan documents in 
 - [ ] **Task:** For all service methods in `src/ClickUp.Api.Client/Services/`, ensure comprehensive unit tests covering:
     - [x] Verification of correct request construction (URL, query parameters, body serialization).
     - [x] Simulation of API error cases (e.g., `HttpRequestException`, specific `ClickUpApiException`s).
-    - [ ] Handling of null or unexpected API responses.
+    - [x] Handling of null or unexpected API responses.
     - [x] Happy path scenarios for all public methods.
     - [x] Simulation of network errors and timeouts. *(Completed for AttachmentsService, CommentService, TaskService. FoldersService, GoalsService, GuestsService also covered as per user update)*
     - [x] Verification of `CancellationToken` pass-through. *(Completed for AttachmentsService, CommentService, TaskService. FoldersService, GoalsService, GuestsService also covered as per user update)*

--- a/src/ClickUp.Api.Client.Tests/ServiceTests/GuestsServiceTests.cs
+++ b/src/ClickUp.Api.Client.Tests/ServiceTests/GuestsServiceTests.cs
@@ -182,7 +182,7 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
         {
             var workspaceId = "ws_edit_err";
             var guestId = "guest_edit_err";
-            var request = new EditGuestOnWorkspaceRequest(false, false, false, false, 0, false);
+            var request = new EditGuestOnWorkspaceRequest(CanEditTags: false, CanSeeTimeEstimated: false, CanSeeTimeSpent: false, CanCreateViews: false, CustomRoleId: 0, CanSeePointsEstimated: false);
             _mockApiConnection.Setup(c => c.PutAsync<EditGuestOnWorkspaceRequest, GetGuestResponse>(It.IsAny<string>(), request, It.IsAny<CancellationToken>())).ThrowsAsync(new HttpRequestException("API error"));
             await Assert.ThrowsAsync<HttpRequestException>(() => _guestsService.EditGuestOnWorkspaceAsync(workspaceId, guestId, request));
         }
@@ -192,7 +192,7 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
         {
             var workspaceId = "ws_edit_null_api";
             var guestId = "guest_edit_null_api";
-            var request = new EditGuestOnWorkspaceRequest(false, false, false, false, 0, false);
+            var request = new EditGuestOnWorkspaceRequest(CanEditTags: false, CanSeeTimeEstimated: false, CanSeeTimeSpent: false, CanCreateViews: false, CustomRoleId: 0, CanSeePointsEstimated: false);
             _mockApiConnection.Setup(c => c.PutAsync<EditGuestOnWorkspaceRequest, GetGuestResponse>(It.IsAny<string>(), request, It.IsAny<CancellationToken>())).ReturnsAsync((GetGuestResponse)null);
             await Assert.ThrowsAsync<InvalidOperationException>(() => _guestsService.EditGuestOnWorkspaceAsync(workspaceId, guestId, request));
         }
@@ -202,7 +202,7 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
         {
             var workspaceId = "ws_edit_null_guest";
             var guestId = "guest_edit_null_guest";
-            var request = new EditGuestOnWorkspaceRequest(false, false, false, false, 0, false);
+            var request = new EditGuestOnWorkspaceRequest(CanEditTags: false, CanSeeTimeEstimated: false, CanSeeTimeSpent: false, CanCreateViews: false, CustomRoleId: 0, CanSeePointsEstimated: false);
             _mockApiConnection.Setup(c => c.PutAsync<EditGuestOnWorkspaceRequest, GetGuestResponse>(It.IsAny<string>(), request, It.IsAny<CancellationToken>())).ReturnsAsync(new GetGuestResponse { Guest = null! });
             await Assert.ThrowsAsync<InvalidOperationException>(() => _guestsService.EditGuestOnWorkspaceAsync(workspaceId, guestId, request));
         }
@@ -526,7 +526,7 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
         {
             var workspaceId = "ws_edit_cancel";
             var guestId = "guest_edit_cancel";
-            var request = new EditGuestOnWorkspaceRequest(false,false,false,false,0,false);
+            var request = new EditGuestOnWorkspaceRequest(CanEditTags: false, CanSeeTimeEstimated: false, CanSeeTimeSpent: false, CanCreateViews: false, CustomRoleId: 0, CanSeePointsEstimated: false);
             _mockApiConnection.Setup(c => c.PutAsync<EditGuestOnWorkspaceRequest, GetGuestResponse>(It.IsAny<string>(), request, It.IsAny<CancellationToken>())).ThrowsAsync(new TaskCanceledException("API timeout"));
             await Assert.ThrowsAsync<TaskCanceledException>(() => _guestsService.EditGuestOnWorkspaceAsync(workspaceId, guestId, request, new CancellationTokenSource().Token));
         }
@@ -536,7 +536,7 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
         {
             var workspaceId = "ws_edit_ct";
             var guestId = "guest_edit_ct";
-            var request = new EditGuestOnWorkspaceRequest(false,false,false,false,0,false);
+            var request = new EditGuestOnWorkspaceRequest(CanEditTags: false, CanSeeTimeEstimated: false, CanSeeTimeSpent: false, CanCreateViews: false, CustomRoleId: 0, CanSeePointsEstimated: false);
             var cts = new CancellationTokenSource();
             var expectedToken = cts.Token;
             var expectedGuest = CreateSampleGuest(int.Parse(guestId.Replace("guest_edit_ct", "400")));
@@ -584,7 +584,7 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
         }
         */
 
-        /*
+
         [Fact]
         public async Task AddGuestToTaskAsync_PassesCancellationTokenToApiConnection()
         {
@@ -593,19 +593,23 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
             var request = new AddGuestToItemRequest { PermissionLevel = 1 };
             var cts = new CancellationTokenSource();
             var expectedToken = cts.Token;
-            var expectedGuest = CreateSampleGuest(int.Parse(guestId.Replace("guest_add_ct", "500")));
+            var expectedGuest = CreateSampleGuest(500); // Simplified guest creation
             _mockApiConnection
-                .Setup(c => c.PostAsync<AddGuestToItemRequest, GetGuestResponse>(It.IsAny<string>(), request, expectedToken))
+                .Setup(c => c.PostAsync<AddGuestToItemRequest, GetGuestResponse>(
+                    $"task/{taskId}/guest/{guestId}", // URL should be exact if no optional params are used
+                    request,
+                    expectedToken))
                 .ReturnsAsync(new GetGuestResponse { Guest = expectedGuest });
 
-            await _guestsService.AddGuestToTaskAsync(taskId, guestId, request, includeShared: null, customTaskIds: null, teamId: null, cancellationToken: expectedToken);
+            // Calling with null for all optional bool? and string? params
+            await _guestsService.AddGuestToTaskAsync(taskId, guestId, request, null, null, null, expectedToken);
 
             _mockApiConnection.Verify(c => c.PostAsync<AddGuestToItemRequest, GetGuestResponse>(
-                $"task/{taskId}/guest/{guestId}", // Basic URL, query params are handled by service method
+                $"task/{taskId}/guest/{guestId}",
                 request,
                 expectedToken), Times.Once);
         }
-        */
+
 
         // RemoveGuestFromTaskAsync
         /*
@@ -623,7 +627,6 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
         }
         */
 
-        /*
         [Fact]
         public async Task RemoveGuestFromTaskAsync_PassesCancellationTokenToApiConnection()
         {
@@ -631,18 +634,21 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
             var guestId = "guest_rem_ct";
             var cts = new CancellationTokenSource();
             var expectedToken = cts.Token;
-            var expectedGuest = CreateSampleGuest(int.Parse(guestId.Replace("guest_rem_ct", "600")));
+            var expectedGuest = CreateSampleGuest(600); // Simplified
             _mockApiConnection
-                .Setup(c => c.DeleteAsync<GetGuestResponse>(It.IsAny<string>(), expectedToken))
+                .Setup(c => c.DeleteAsync<GetGuestResponse>(
+                    $"task/{taskId}/guest/{guestId}", // URL should be exact
+                    expectedToken))
                 .ReturnsAsync(new GetGuestResponse { Guest = expectedGuest });
 
-            await _guestsService.RemoveGuestFromTaskAsync(taskId, guestId, includeShared: null, customTaskIds: null, teamId: null, cancellationToken: expectedToken);
+            // Calling with null for all optional bool? and string? params
+            await _guestsService.RemoveGuestFromTaskAsync(taskId, guestId, null, null, null, expectedToken);
 
             _mockApiConnection.Verify(c => c.DeleteAsync<GetGuestResponse>(
-                $"task/{taskId}/guest/{guestId}", // Basic URL, query params are handled by service method
+                $"task/{taskId}/guest/{guestId}",
                 expectedToken), Times.Once);
         }
-        */
+
 
         // AddGuestToListAsync
         [Fact]


### PR DESCRIPTION
…ice tests

This commit addresses several build errors that were preventing the solution from compiling successfully.

Key changes:
- Updated `ConsolidatedPlan.md` to reflect progress on unit test coverage.
- In `UserGroupServiceTests.cs`:
    - Corrected DTO usage for `UserGroup`, `CreateUserGroupRequest`, and `UpdateUserGroupRequest`.
    - Ensured helper methods align with DTO definitions.
    - Added missing 'using' directive for the `Member` type.
- In `GuestsServiceTests.cs`:
    - Resolved CS1503 errors by ensuring all calls to the `EditGuestOnWorkspaceRequest` constructor use named arguments, clarifying parameter types for the compiler.
    - Uncommented and corrected CancellationToken pass-through tests for `*GuestToTaskAsync` methods.
- In `TimeTrackingServiceTests.cs`:
    - Fixed CS0029 by converting Unix millisecond timestamps to `DateTimeOffset` for `GetTimeEntriesRequest` properties.

The solution now builds successfully. The next step would be to run unit tests and address any failures or missing coverage, including locating or creating the `coverlet.runsettings` file needed for code coverage analysis.