### PR TITLE
Add integration tests for WorkspacesService

### DIFF
--- a/src/ClickUp.Api.Client.Abstractions/Options/ClickUpClientOptions.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Options/ClickUpClientOptions.cs
@@ -27,6 +27,12 @@ public class ClickUpClientOptions
     /// </summary>
     public string BaseAddress { get; set; } = "https://api.clickup.com/api/v2/";
 
+    /// <summary>
+    /// Gets or sets the Workspace ID (Team ID) to be used in integration tests.
+    /// This is often required as part of the API URL path.
+    /// </summary>
+    public string? TestWorkspaceId { get; set; }
+
     // Other OAuth properties like ClientId, ClientSecret, RefreshToken, TokenExpiresAt
     // are not included here as this library focuses on consuming a pre-acquired access token.
     // Handling the OAuth flow itself or token refresh mechanisms are outside the current scope.

--- a/src/ClickUp.Api.Client.IntegrationTests/ClickUp.Api.Client.IntegrationTests.csproj
+++ b/src/ClickUp.Api.Client.IntegrationTests/ClickUp.Api.Client.IntegrationTests.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" /> <!-- Added FluentAssertions -->
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ClickUp.Api.Client.IntegrationTests/Integration/WorkspaceServiceIntegrationTests.cs
+++ b/src/ClickUp.Api.Client.IntegrationTests/Integration/WorkspaceServiceIntegrationTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using ClickUp.Api.Client.Abstractions.Services;
+using ClickUp.Api.Client.Models.ResponseModels.Workspaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using RichardSzalay.MockHttp; // Added for MockHttpHandler extension methods like .When()
+using Xunit;
+using Xunit.Abstractions; // For ITestOutputHelper if needed later
+
+namespace ClickUp.Api.Client.IntegrationTests.Integration
+{
+    [Trait("Category", "Integration")]
+    public class WorkspaceServiceIntegrationTests : IntegrationTestBase
+    {
+        private readonly IWorkspacesService _workspacesService;
+        private readonly string _workspaceId;
+
+        public WorkspaceServiceIntegrationTests() : base() // Add ITestOutputHelper if logging to test output
+        {
+            _workspacesService = ServiceProvider.GetRequiredService<IWorkspacesService>();
+
+            // Ensure TestWorkspaceId is available, especially for Record/Passthrough modes
+            if (string.IsNullOrWhiteSpace(ClientOptions.TestWorkspaceId) && CurrentTestMode != TestMode.Playback)
+            {
+                throw new InvalidOperationException(
+                    "ClickUp TestWorkspaceId not configured for integration tests. " +
+                    "Set via User Secrets (e.g., 'ClickUpApi:TestWorkspaceId') " +
+                    "or Environment Variables (e.g., 'ClickUpApi__TestWorkspaceId'). " +
+                    "Not strictly required for Playback if all paths are fully mocked, but good practice.");
+            }
+            _workspaceId = ClientOptions.TestWorkspaceId ?? "mock_workspace_id_for_playback"; // Fallback for playback if not set
+        }
+
+        [Fact]
+        public async Task GetWorkspaceSeatsAsync_WhenApiCallIsSuccessful_ReturnsSeats()
+        {
+            // Arrange
+            if (CurrentTestMode == TestMode.Playback)
+            {
+                Assert.NotNull(MockHttpHandler);
+                var responsePath = Path.Combine(RecordedResponsesBasePath, "WorkspacesService", "GetWorkspaceSeatsAsync", "Success.json");
+                if (!File.Exists(responsePath))
+                {
+                    throw new FileNotFoundException($"Mock response file not found: {responsePath}. Ensure it's created for Playback mode.");
+                }
+                var responseContent = await File.ReadAllTextAsync(responsePath);
+                MockHttpHandler.When($"https://api.clickup.com/api/v2/team/{_workspaceId}/seats")
+                               .Respond(HttpStatusCode.OK, "application/json", responseContent);
+            }
+
+            // Act
+            var response = await _workspacesService.GetWorkspaceSeatsAsync(_workspaceId);
+
+            // Assert
+            response.Should().NotBeNull();
+            response.Members.Should().NotBeNull(); // Changed from response.Seats
+            response.Guests.Should().NotBeNull();  // Changed from response.Seats
+            // Deeper assertions can be added based on WorkspaceMemberSeatsInfo and WorkspaceGuestSeatsInfo
+            // For example:
+            // response.Members.FilledSeats.Should().BeGreaterOrEqualTo(0);
+            // response.Guests.FilledSeats.Should().BeGreaterOrEqualTo(0);
+        }
+
+        [Fact]
+        public async Task GetWorkspacePlanAsync_WhenApiCallIsSuccessful_ReturnsPlan()
+        {
+            // Arrange
+            if (CurrentTestMode == TestMode.Playback)
+            {
+                Assert.NotNull(MockHttpHandler);
+                var responsePath = Path.Combine(RecordedResponsesBasePath, "WorkspacesService", "GetWorkspacePlanAsync", "Success.json");
+                if (!File.Exists(responsePath))
+                {
+                    throw new FileNotFoundException($"Mock response file not found: {responsePath}. Ensure it's created for Playback mode.");
+                }
+                var responseContent = await File.ReadAllTextAsync(responsePath);
+                MockHttpHandler.When($"https://api.clickup.com/api/v2/team/{_workspaceId}/plan")
+                               .Respond(HttpStatusCode.OK, "application/json", responseContent);
+            }
+
+            // Act
+            var response = await _workspacesService.GetWorkspacePlanAsync(_workspaceId);
+
+            // Assert
+            response.Should().NotBeNull();
+            response.PlanName.Should().NotBeNullOrEmpty(); // Changed from response.Plan
+            response.PlanId.Should().BePositive();       // Changed from response.Plan and added a more specific check
+            // Deeper assertions can be added based on actual plan details
+            // For example:
+            // response.PlanName.Should().Be("Free Forever"); // If that's what the mock returns
+        }
+    }
+}

--- a/src/ClickUp.Api.Client.IntegrationTests/test-data/recorded-responses/WorkspacesService/GetWorkspacePlanAsync/Success.json
+++ b/src/ClickUp.Api.Client.IntegrationTests/test-data/recorded-responses/WorkspacesService/GetWorkspacePlanAsync/Success.json
@@ -1,0 +1,4 @@
+{
+  "plan_name": "Free Forever",
+  "plan_id": 12345
+}

--- a/src/ClickUp.Api.Client.IntegrationTests/test-data/recorded-responses/WorkspacesService/GetWorkspaceSeatsAsync/Success.json
+++ b/src/ClickUp.Api.Client.IntegrationTests/test-data/recorded-responses/WorkspacesService/GetWorkspaceSeatsAsync/Success.json
@@ -1,0 +1,10 @@
+{
+  "members": {
+    "filled_seats": 2,
+    "total_seats": 5
+  },
+  "guests": {
+    "filled_seats": 1,
+    "total_seats": 5
+  }
+}


### PR DESCRIPTION
- Created WorkspaceServiceIntegrationTests with tests for GetWorkspaceSeatsAsync and GetWorkspacePlanAsync.
- Implemented Playback mode support using mock JSON responses.
- Added dummy JSON response files for offline testing.
- Updated ClickUpClientOptions to include TestWorkspaceId.
- Ensured IntegrationTestBase loads and validates TestWorkspaceId.
- Corrected response model usage in tests and updated mock JSON to align with C# models.
- Added FluentAssertions package to IntegrationTests project.