### PR TITLE
Refactor TaskService methods to use Request DTOs

### DIFF
--- a/src/ClickUp.Api.Client.Abstractions/Services/ITasksService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/ITasksService.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using ClickUp.Api.Client.Models.Entities.Tasks;
+// Make sure this using is present for GetFilteredTeamTasksRequest
 using ClickUp.Api.Client.Models.RequestModels.Tasks;
 using ClickUp.Api.Client.Models.ResponseModels.Tasks;
 
@@ -129,66 +130,18 @@ namespace ClickUp.Api.Client.Abstractions.Services
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Retrieves Tasks from a Workspace (Team) based on a comprehensive set of filters.
+        /// Retrieves Tasks from a Workspace (Team) based on a comprehensive set of filters provided in the <paramref name="requestModel"/>.
         /// </summary>
         /// <param name="workspaceId">The unique identifier of the Workspace (Team).</param>
-        /// <param name="page">Optional. The page number to fetch for pagination (0-indexed).</param>
-        /// <param name="orderBy">Optional. Field to order Tasks by.</param>
-        /// <param name="reverse">Optional. If true, reverses the sort order.</param>
-        /// <param name="subtasks">Optional. If true, includes subtasks in the results.</param>
-        /// <param name="spaceIds">Optional. An enumerable of Space IDs to filter by.</param>
-        /// <param name="projectIds">Optional. An enumerable of Project IDs (Folders) to filter by.</param>
-        /// <param name="listIds">Optional. An enumerable of List IDs to filter by.</param>
-        /// <param name="statuses">Optional. An enumerable of status names or IDs to filter by.</param>
-        /// <param name="includeClosed">Optional. If true, includes closed Tasks.</param>
-        /// <param name="assignees">Optional. An enumerable of user IDs to filter by assignees.</param>
-        /// <param name="tags">Optional. An enumerable of tag names to filter by.</param>
-        /// <param name="dueDateGreaterThan">Optional. Filters for Tasks with a due date after this Unix timestamp (ms).</param>
-        /// <param name="dueDateLessThan">Optional. Filters for Tasks with a due date before this Unix timestamp (ms).</param>
-        /// <param name="dateCreatedGreaterThan">Optional. Filters for Tasks created after this Unix timestamp (ms).</param>
-        /// <param name="dateCreatedLessThan">Optional. Filters for Tasks created before this Unix timestamp (ms).</param>
-        /// <param name="dateUpdatedGreaterThan">Optional. Filters for Tasks updated after this Unix timestamp (ms).</param>
-        /// <param name="dateUpdatedLessThan">Optional. Filters for Tasks updated before this Unix timestamp (ms).</param>
-        /// <param name="customFields">Optional. A JSON string representing an array of custom field filters.</param>
-        /// <param name="customTaskIds">Optional. If true, indicates that task IDs used in other filters (like projectIds, listIds if they can contain task IDs) are custom task IDs. Also affects how task IDs are exported/returned if applicable.</param>
-        /// <param name="teamIdForCustomTaskIds">Optional. The Workspace ID (team_id), required if <paramref name="customTaskIds"/> is true and custom task IDs are used in filters.</param>
-        /// <param name="customItems">Optional. An enumerable of custom item type IDs (long integers) to filter Tasks by.</param>
-        /// <param name="dateDoneGreaterThan">Optional. Filters for Tasks completed after this Unix timestamp (in milliseconds).</param>
-        /// <param name="dateDoneLessThan">Optional. Filters for Tasks completed before this Unix timestamp (in milliseconds).</param>
-        /// <param name="parentTaskId">Optional. Filters for subtasks of a specific parent Task ID.</param>
-        /// <param name="includeMarkdownDescription">Optional. If set to <c>true</c>, returns Task descriptions in Markdown format. Defaults to <c>false</c>.</param>
+        /// <param name="requestModel">An object containing various filtering and sorting options such as pagination, ordering, subtasks, statuses, assignees, tags, due dates, creation dates, update dates, completion dates, custom fields, custom items, parent task ID, and more.</param>
         /// <param name="cancellationToken">A token to observe while waiting for the task to complete, allowing cancellation of the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains a <see cref="GetTasksResponse"/> object with the list of matching Tasks and pagination details.</returns>
-        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> is null or empty.</exception>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="requestModel"/> is null.</exception>
         /// <exception cref="Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access Tasks in this Workspace.</exception>
         /// <exception cref="Models.Exceptions.ClickUpApiException">Thrown for other API call failures.</exception>
         Task<GetTasksResponse> GetFilteredTeamTasksAsync(
             string workspaceId,
-            int? page = null,
-            string? orderBy = null,
-            bool? reverse = null,
-            bool? subtasks = null,
-            IEnumerable<string>? spaceIds = null,
-            IEnumerable<string>? projectIds = null,
-            IEnumerable<string>? listIds = null,
-            IEnumerable<string>? statuses = null,
-            bool? includeClosed = null,
-            IEnumerable<string>? assignees = null,
-            IEnumerable<string>? tags = null,
-            long? dueDateGreaterThan = null,
-            long? dueDateLessThan = null,
-            long? dateCreatedGreaterThan = null,
-            long? dateCreatedLessThan = null,
-            long? dateUpdatedGreaterThan = null,
-            long? dateUpdatedLessThan = null,
-            string? customFields = null,
-            bool? customTaskIds = null,
-            string? teamIdForCustomTaskIds = null,
-            IEnumerable<long>? customItems = null,
-            long? dateDoneGreaterThan = null,
-            long? dateDoneLessThan = null,
-            string? parentTaskId = null,
-            bool? includeMarkdownDescription = null,
+            GetFilteredTeamTasksRequest requestModel,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -270,119 +223,35 @@ namespace ClickUp.Api.Client.Abstractions.Services
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Retrieves all Tasks within a specific List, automatically handling pagination using <see cref="IAsyncEnumerable{T}"/>.
+        /// Retrieves all Tasks within a specific List, automatically handling pagination using <see cref="IAsyncEnumerable{T}"/>, with filtering options provided by <paramref name="requestModel"/>.
         /// </summary>
         /// <param name="listId">The unique identifier of the List.</param>
-        /// <param name="archived">Optional. If set to <c>true</c>, includes archived Tasks. Defaults to <c>false</c>.</param>
-        /// <param name="includeMarkdownDescription">Optional. If set to <c>true</c>, returns Task descriptions in Markdown format. Defaults to <c>false</c>.</param>
-        /// <param name="orderBy">Optional. Field to order Tasks by.</param>
-        /// <param name="reverse">Optional. If true, reverses the sort order.</param>
-        /// <param name="subtasks">Optional. If true, includes subtasks.</param>
-        /// <param name="statuses">Optional. An enumerable of status names or IDs to filter by.</param>
-        /// <param name="includeClosed">Optional. If true, includes closed Tasks.</param>
-        /// <param name="assignees">Optional. An enumerable of user IDs to filter by assignees.</param>
-        /// <param name="watchers">Optional. An enumerable of user IDs to filter by watchers.</param>
-        /// <param name="tags">Optional. An enumerable of tag names to filter by.</param>
-        /// <param name="dueDateGreaterThan">Optional. Filters for Tasks with a due date after this Unix timestamp (ms).</param>
-        /// <param name="dueDateLessThan">Optional. Filters for Tasks with a due date before this Unix timestamp (ms).</param>
-        /// <param name="dateCreatedGreaterThan">Optional. Filters for Tasks created after this Unix timestamp (ms).</param>
-        /// <param name="dateCreatedLessThan">Optional. Filters for Tasks created before this Unix timestamp (ms).</param>
-        /// <param name="dateUpdatedGreaterThan">Optional. Filters for Tasks updated after this Unix timestamp (ms).</param>
-        /// <param name="dateUpdatedLessThan">Optional. Filters for Tasks updated before this Unix timestamp (ms).</param>
-        /// <param name="dateDoneGreaterThan">Optional. Filters for Tasks completed after this Unix timestamp (ms).</param>
-        /// <param name="dateDoneLessThan">Optional. Filters for Tasks completed before this Unix timestamp (ms).</param>
-        /// <param name="customFields">Optional. A JSON string representing an array of custom field filters.</param>
-        /// <param name="customItems">Optional. An enumerable of custom item type IDs to filter by.</param>
+        /// <param name="requestModel">An object containing various filtering and sorting options such as archived status, pagination (Page property ignored for initial call), ordering, subtasks, statuses, assignees, tags, due dates, creation dates, update dates, completion dates, custom fields, and custom items.</param>
         /// <param name="cancellationToken">A token to observe while waiting for the task to complete, allowing cancellation of the operation.</param>
         /// <returns>An asynchronous stream of <see cref="CuTask"/> objects from the specified List.</returns>
-        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="listId"/> is null or empty.</exception>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="listId"/> or <paramref name="requestModel"/> is null.</exception>
         /// <exception cref="Models.Exceptions.ClickUpApiNotFoundException">Thrown if the List with the specified ID does not exist.</exception>
         /// <exception cref="Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access Tasks in this List.</exception>
         /// <exception cref="Models.Exceptions.ClickUpApiException">Thrown if an API call fails during the pagination process.</exception>
         IAsyncEnumerable<CuTask> GetTasksAsyncEnumerableAsync(
             string listId,
-            bool? archived = null,
-            bool? includeMarkdownDescription = null,
-            string? orderBy = null,
-            bool? reverse = null,
-            bool? subtasks = null,
-            IEnumerable<string>? statuses = null,
-            bool? includeClosed = null,
-            IEnumerable<string>? assignees = null,
-            IEnumerable<string>? watchers = null,
-            IEnumerable<string>? tags = null,
-            long? dueDateGreaterThan = null,
-            long? dueDateLessThan = null,
-            long? dateCreatedGreaterThan = null,
-            long? dateCreatedLessThan = null,
-            long? dateUpdatedGreaterThan = null,
-            long? dateUpdatedLessThan = null,
-            long? dateDoneGreaterThan = null,
-            long? dateDoneLessThan = null,
-            string? customFields = null,
-            IEnumerable<long>? customItems = null,
+            GetTasksRequest requestModel,
             CancellationToken cancellationToken = default
         );
 
         /// <summary>
-        /// Retrieves all Tasks from a Workspace (Team) based on a comprehensive set of filters, automatically handling pagination using <see cref="IAsyncEnumerable{T}"/>.
+        /// Retrieves all Tasks from a Workspace (Team) based on a comprehensive set of filters provided in the <paramref name="requestModel"/>, automatically handling pagination using <see cref="IAsyncEnumerable{T}"/>.
         /// </summary>
         /// <param name="workspaceId">The unique identifier of the Workspace (Team).</param>
-        /// <param name="orderBy">Optional. Field to order Tasks by.</param>
-        /// <param name="reverse">Optional. If true, reverses the sort order.</param>
-        /// <param name="subtasks">Optional. If true, includes subtasks in the results.</param>
-        /// <param name="spaceIds">Optional. An enumerable of Space IDs to filter by.</param>
-        /// <param name="projectIds">Optional. An enumerable of Project IDs (Folders) to filter by.</param>
-        /// <param name="listIds">Optional. An enumerable of List IDs to filter by.</param>
-        /// <param name="statuses">Optional. An enumerable of status names or IDs to filter by.</param>
-        /// <param name="includeClosed">Optional. If true, includes closed Tasks.</param>
-        /// <param name="assignees">Optional. An enumerable of user IDs to filter by assignees.</param>
-        /// <param name="tags">Optional. An enumerable of tag names to filter by.</param>
-        /// <param name="dueDateGreaterThan">Optional. Filters for Tasks with a due date after this Unix timestamp (ms).</param>
-        /// <param name="dueDateLessThan">Optional. Filters for Tasks with a due date before this Unix timestamp (ms).</param>
-        /// <param name="dateCreatedGreaterThan">Optional. Filters for Tasks created after this Unix timestamp (ms).</param>
-        /// <param name="dateCreatedLessThan">Optional. Filters for Tasks created before this Unix timestamp (ms).</param>
-        /// <param name="dateUpdatedGreaterThan">Optional. Filters for Tasks updated after this Unix timestamp (ms).</param>
-        /// <param name="dateUpdatedLessThan">Optional. Filters for Tasks updated before this Unix timestamp (ms).</param>
-        /// <param name="customFields">Optional. A JSON string representing an array of custom field filters.</param>
-        /// <param name="customTaskIds">Optional. If true, indicates that task IDs used in other filters are custom task IDs.</param>
-        /// <param name="teamIdForCustomTaskIds">Optional. The Workspace ID (team_id), required if <paramref name="customTaskIds"/> is true.</param>
-        /// <param name="customItems">Optional. An enumerable of custom item type IDs (long integers) to filter Tasks by.</param>
-        /// <param name="dateDoneGreaterThan">Optional. Filters for Tasks completed after this Unix timestamp (in milliseconds).</param>
-        /// <param name="dateDoneLessThan">Optional. Filters for Tasks completed before this Unix timestamp (in milliseconds).</param>
-        /// <param name="parentTaskId">Optional. Filters for subtasks of a specific parent Task ID.</param>
-        /// <param name="includeMarkdownDescription">Optional. If set to <c>true</c>, returns Task descriptions in Markdown format. Defaults to <c>false</c>.</param>
+        /// <param name="requestModel">An object containing various filtering and sorting options such as pagination, ordering, subtasks, statuses, assignees, tags, due dates, creation dates, update dates, completion dates, custom fields, custom items, parent task ID, and more. The `Page` property within this model will be ignored for the initial call but used for subsequent pagination calls.</param>
         /// <param name="cancellationToken">A token to observe while waiting for the task to complete, allowing cancellation of the operation.</param>
         /// <returns>An asynchronous stream of <see cref="CuTask"/> objects from the specified Workspace matching the filters.</returns>
-        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> is null or empty.</exception>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="requestModel"/> is null.</exception>
         /// <exception cref="Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access Tasks in this Workspace.</exception>
         /// <exception cref="Models.Exceptions.ClickUpApiException">Thrown if an API call fails during the pagination process.</exception>
         IAsyncEnumerable<CuTask> GetFilteredTeamTasksAsyncEnumerableAsync(
             string workspaceId,
-            string? orderBy = null,
-            bool? reverse = null,
-            bool? subtasks = null,
-            IEnumerable<string>? spaceIds = null,
-            IEnumerable<string>? projectIds = null,
-            IEnumerable<string>? listIds = null,
-            IEnumerable<string>? statuses = null,
-            bool? includeClosed = null,
-            IEnumerable<string>? assignees = null,
-            IEnumerable<string>? tags = null,
-            long? dueDateGreaterThan = null,
-            long? dueDateLessThan = null,
-            long? dateCreatedGreaterThan = null,
-            long? dateCreatedLessThan = null,
-            long? dateUpdatedGreaterThan = null,
-            long? dateUpdatedLessThan = null,
-            string? customFields = null,
-            bool? customTaskIds = null,
-            string? teamIdForCustomTaskIds = null,
-            IEnumerable<long>? customItems = null,
-            long? dateDoneGreaterThan = null,
-            long? dateDoneLessThan = null,
-            string? parentTaskId = null,
-            bool? includeMarkdownDescription = null,
+            GetFilteredTeamTasksRequest requestModel,
             CancellationToken cancellationToken = default
         );
     }

--- a/src/ClickUp.Api.Client.Tests/ServiceTests/Fluent/FluentTasksApiTests.cs
+++ b/src/ClickUp.Api.Client.Tests/ServiceTests/Fluent/FluentTasksApiTests.cs
@@ -69,32 +69,8 @@ public class FluentTasksApiTests
 
         var mockTasksService = new Mock<ITasksService>();
         mockTasksService.Setup(x => x.GetFilteredTeamTasksAsync(
-            It.IsAny<string>(),
-            It.IsAny<int?>(),
-            It.IsAny<string?>(),
-            It.IsAny<bool?>(),
-            It.IsAny<bool?>(),
-            It.IsAny<IEnumerable<string>?>(),
-            It.IsAny<IEnumerable<string>?>(),
-            It.IsAny<IEnumerable<string>?>(),
-            It.IsAny<IEnumerable<string>?>(),
-            It.IsAny<bool?>(),
-            It.IsAny<IEnumerable<string>?>(),
-            It.IsAny<IEnumerable<string>?>(),
-            It.IsAny<long?>(),
-            It.IsAny<long?>(),
-            It.IsAny<long?>(),
-            It.IsAny<long?>(),
-            It.IsAny<long?>(),
-            It.IsAny<long?>(),
-            It.IsAny<string?>(),
-            It.IsAny<bool?>(),
-            It.IsAny<string?>(),
-            It.IsAny<IEnumerable<long>?>(),
-            It.IsAny<long?>(),
-            It.IsAny<long?>(),
-            It.IsAny<string?>(),
-            It.IsAny<bool?>(),
+            It.IsAny<string>(), // workspaceId
+            It.IsAny<Client.Models.RequestModels.Tasks.GetFilteredTeamTasksRequest>(), // requestModel
             It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedResponse);
 
@@ -110,31 +86,10 @@ public class FluentTasksApiTests
         Assert.Equal(expectedResponse, result);
         mockTasksService.Verify(x => x.GetFilteredTeamTasksAsync(
             workspaceId,
-            null, // page
-            null, // orderBy
-            null, // reverse
-            true, // subtasks
-            null, // spaceIds
-            null, // projectIds
-            null, // listIds
-            null, // statuses
-            false, // includeClosed
-            null, // assignees
-            null, // tags
-            null, // dueDateGreaterThan
-            null, // dueDateLessThan
-            null, // dateCreatedGreaterThan
-            null, // dateCreatedLessThan
-            null, // dateUpdatedGreaterThan
-            null, // dateUpdatedLessThan
-            null, // customFields
-            null, // customTaskIds
-            null, // teamIdForCustomTaskIds
-            null, // customItems
-            null, // dateDoneGreaterThan
-            null, // dateDoneLessThan
-            null, // parentTaskId
-            null, // includeMarkdownDescription
+            It.Is<Client.Models.RequestModels.Tasks.GetFilteredTeamTasksRequest>(req =>
+                req.Subtasks == true &&
+                req.IncludeClosed == false
+            ),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/src/ClickUp.Api.Client.Tests/ServiceTests/TaskServiceTests.cs
+++ b/src/ClickUp.Api.Client.Tests/ServiceTests/TaskServiceTests.cs
@@ -197,12 +197,16 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
             var expectedEndpoint = $"team/{workspaceId}/task?date_done_gt={dateDoneGreaterThan}&date_done_lt={dateDoneLessThan}&parent={parentTaskId}&include_markdown_description=true";
 
             // Act
+            var requestModel = new ClickUp.Api.Client.Models.RequestModels.Tasks.GetFilteredTeamTasksRequest
+            {
+                DateDoneGreaterThan = dateDoneGreaterThan,
+                DateDoneLessThan = dateDoneLessThan,
+                ParentTaskId = parentTaskId,
+                IncludeMarkdownDescription = includeMarkdownDescription
+            };
             await _taskService.GetFilteredTeamTasksAsync(
                 workspaceId,
-                dateDoneGreaterThan: dateDoneGreaterThan,
-                dateDoneLessThan: dateDoneLessThan,
-                parentTaskId: parentTaskId,
-                includeMarkdownDescription: includeMarkdownDescription,
+                requestModel,
                 cancellationToken: CancellationToken.None);
 
             // Assert
@@ -236,16 +240,20 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
             var expectedEndpoint = $"team/{workspaceId}/task?page={page}&order_by={orderBy}&date_done_lt={dateDoneLessThan}&include_markdown_description=false&statuses[]={Uri.EscapeDataString(statuses[0])}&statuses[]={Uri.EscapeDataString(statuses[1])}&assignees[]={assignees[0]}&assignees[]={assignees[1]}";
 
             // Act
+            var requestModel = new ClickUp.Api.Client.Models.RequestModels.Tasks.GetFilteredTeamTasksRequest
+            {
+                Page = page,
+                OrderBy = orderBy,
+                DateDoneGreaterThan = dateDoneGreaterThan,
+                DateDoneLessThan = dateDoneLessThan,
+                ParentTaskId = parentTaskId,
+                IncludeMarkdownDescription = includeMarkdownDescription,
+                Statuses = statuses,
+                Assignees = assignees
+            };
             await _taskService.GetFilteredTeamTasksAsync(
                 workspaceId,
-                page: page,
-                orderBy: orderBy,
-                dateDoneGreaterThan: dateDoneGreaterThan,
-                dateDoneLessThan: dateDoneLessThan,
-                parentTaskId: parentTaskId,
-                includeMarkdownDescription: includeMarkdownDescription,
-                statuses: statuses,
-                assignees: assignees,
+                requestModel,
                 cancellationToken: CancellationToken.None);
 
             // Assert
@@ -256,18 +264,11 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
         public async Task GetFilteredTeamTasksAsync_NullWorkspaceId_ThrowsArgumentNullException()
         {
             // Act & Assert
+            var requestModel = new ClickUp.Api.Client.Models.RequestModels.Tasks.GetFilteredTeamTasksRequest(); // Empty request
             await Assert.ThrowsAsync<ArgumentNullException>("workspaceId", () =>
                 _taskService.GetFilteredTeamTasksAsync(
                     workspaceId: null!,
-                    page: null, orderBy: null, reverse: null, subtasks: null,
-                    spaceIds: null, projectIds: null, listIds: null, statuses: null,
-                    includeClosed: null, assignees: null, tags: null,
-                    dueDateGreaterThan: null, dueDateLessThan: null,
-                    dateCreatedGreaterThan: null, dateCreatedLessThan: null,
-                    dateUpdatedGreaterThan: null, dateUpdatedLessThan: null,
-                    customFields: null, customTaskIds: null, teamIdForCustomTaskIds: null,
-                    customItems: null, dateDoneGreaterThan: null, dateDoneLessThan: null,
-                    parentTaskId: null, includeMarkdownDescription: null)
+                    requestModel)
             );
         }
 
@@ -275,18 +276,11 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
         public async Task GetFilteredTeamTasksAsync_EmptyWorkspaceId_ThrowsArgumentNullException()
         {
             // Act & Assert
+            var requestModel = new ClickUp.Api.Client.Models.RequestModels.Tasks.GetFilteredTeamTasksRequest(); // Empty request
             await Assert.ThrowsAsync<ArgumentNullException>("workspaceId", () =>
                 _taskService.GetFilteredTeamTasksAsync(
                     workspaceId: "",
-                    page: null, orderBy: null, reverse: null, subtasks: null,
-                    spaceIds: null, projectIds: null, listIds: null, statuses: null,
-                    includeClosed: null, assignees: null, tags: null,
-                    dueDateGreaterThan: null, dueDateLessThan: null,
-                    dateCreatedGreaterThan: null, dateCreatedLessThan: null,
-                    dateUpdatedGreaterThan: null, dateUpdatedLessThan: null,
-                    customFields: null, customTaskIds: null, teamIdForCustomTaskIds: null,
-                    customItems: null, dateDoneGreaterThan: null, dateDoneLessThan: null,
-                    parentTaskId: null, includeMarkdownDescription: null)
+                    requestModel)
             );
         }
 
@@ -294,18 +288,11 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
         public async Task GetFilteredTeamTasksAsync_WhitespaceWorkspaceId_ThrowsArgumentNullException()
         {
             // Act & Assert
+            var requestModel = new ClickUp.Api.Client.Models.RequestModels.Tasks.GetFilteredTeamTasksRequest(); // Empty request
             await Assert.ThrowsAsync<ArgumentNullException>("workspaceId", () =>
                 _taskService.GetFilteredTeamTasksAsync(
                     workspaceId: "   ",
-                    page: null, orderBy: null, reverse: null, subtasks: null,
-                    spaceIds: null, projectIds: null, listIds: null, statuses: null,
-                    includeClosed: null, assignees: null, tags: null,
-                    dueDateGreaterThan: null, dueDateLessThan: null,
-                    dateCreatedGreaterThan: null, dateCreatedLessThan: null,
-                    dateUpdatedGreaterThan: null, dateUpdatedLessThan: null,
-                    customFields: null, customTaskIds: null, teamIdForCustomTaskIds: null,
-                    customItems: null, dateDoneGreaterThan: null, dateDoneLessThan: null,
-                    parentTaskId: null, includeMarkdownDescription: null)
+                    requestModel)
             );
         }
 
@@ -317,20 +304,13 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
             _mockApiConnection
                 .Setup(x => x.GetAsync<ClickUp.Api.Client.Models.ResponseModels.Tasks.GetTasksResponse>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((ClickUp.Api.Client.Models.ResponseModels.Tasks.GetTasksResponse?)null);
+            var requestModel = new ClickUp.Api.Client.Models.RequestModels.Tasks.GetFilteredTeamTasksRequest(); // Empty request
 
             // Act & Assert
             await Assert.ThrowsAsync<InvalidOperationException>(() =>
                 _taskService.GetFilteredTeamTasksAsync(
                     workspaceId: workspaceId,
-                    page: null, orderBy: null, reverse: null, subtasks: null,
-                    spaceIds: null, projectIds: null, listIds: null, statuses: null,
-                    includeClosed: null, assignees: null, tags: null,
-                    dueDateGreaterThan: null, dueDateLessThan: null,
-                    dateCreatedGreaterThan: null, dateCreatedLessThan: null,
-                    dateUpdatedGreaterThan: null, dateUpdatedLessThan: null,
-                    customFields: null, customTaskIds: null, teamIdForCustomTaskIds: null,
-                    customItems: null, dateDoneGreaterThan: null, dateDoneLessThan: null,
-                    parentTaskId: null, includeMarkdownDescription: null)
+                    requestModel)
             );
         }
 
@@ -370,9 +350,10 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
                 .ReturnsAsync(new GetTasksResponse(secondPageTasks, true));  // Page 1, Last page
 
             var allTasks = new List<CuTask>();
+            var requestModel = new ClickUp.Api.Client.Models.RequestModels.Tasks.GetFilteredTeamTasksRequest();
 
             // Act
-            await foreach (var task in _taskService.GetFilteredTeamTasksAsyncEnumerableAsync(workspaceId, cancellationToken: CancellationToken.None))
+            await foreach (var task in _taskService.GetFilteredTeamTasksAsyncEnumerableAsync(workspaceId, requestModel, cancellationToken: CancellationToken.None))
             {
                 allTasks.Add(task);
             }
@@ -400,9 +381,10 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
                 .ReturnsAsync(new GetTasksResponse(new List<CuTask>(), true)); // Empty list, is last page
 
             var count = 0;
+            var requestModel = new ClickUp.Api.Client.Models.RequestModels.Tasks.GetFilteredTeamTasksRequest();
 
             // Act
-            await foreach (var _ in _taskService.GetFilteredTeamTasksAsyncEnumerableAsync(workspaceId, cancellationToken: CancellationToken.None))
+            await foreach (var _ in _taskService.GetFilteredTeamTasksAsyncEnumerableAsync(workspaceId, requestModel, cancellationToken: CancellationToken.None))
             {
                 count++;
             }
@@ -425,9 +407,10 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
                 .ReturnsAsync(new GetTasksResponse(tasks, true)); // Tasks, is last page
 
             var allTasks = new List<CuTask>();
+            var requestModel = new ClickUp.Api.Client.Models.RequestModels.Tasks.GetFilteredTeamTasksRequest();
 
             // Act
-            await foreach (var task in _taskService.GetFilteredTeamTasksAsyncEnumerableAsync(workspaceId, cancellationToken: CancellationToken.None))
+            await foreach (var task in _taskService.GetFilteredTeamTasksAsyncEnumerableAsync(workspaceId, requestModel, cancellationToken: CancellationToken.None))
             {
                 allTasks.Add(task);
             }
@@ -453,9 +436,10 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
             var tasksProcessed = 0;
 
             // Act & Assert
+            var requestModel = new ClickUp.Api.Client.Models.RequestModels.Tasks.GetFilteredTeamTasksRequest();
             await Assert.ThrowsAsync<OperationCanceledException>(async () =>
             {
-                await foreach (var task in _taskService.GetFilteredTeamTasksAsyncEnumerableAsync(workspaceId, cancellationToken: cts.Token))
+                await foreach (var task in _taskService.GetFilteredTeamTasksAsyncEnumerableAsync(workspaceId, requestModel, cancellationToken: cts.Token))
                 {
                     tasksProcessed++;
                     if (tasksProcessed == 1)
@@ -480,9 +464,10 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
                 .ThrowsAsync(new HttpRequestException("API call failed"));
 
             // Act & Assert
+            var requestModel = new ClickUp.Api.Client.Models.RequestModels.Tasks.GetFilteredTeamTasksRequest();
             await Assert.ThrowsAsync<HttpRequestException>(async () =>
             {
-                await foreach (var _ in _taskService.GetFilteredTeamTasksAsyncEnumerableAsync(workspaceId, cancellationToken: CancellationToken.None))
+                await foreach (var _ in _taskService.GetFilteredTeamTasksAsyncEnumerableAsync(workspaceId, requestModel, cancellationToken: CancellationToken.None))
                 {
                     // Should not reach here
                 }
@@ -549,8 +534,9 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
                 .ThrowsAsync(new TaskCanceledException("Simulated API timeout"));
 
             // Act & Assert
+            var requestModel = new ClickUp.Api.Client.Models.RequestModels.Tasks.GetFilteredTeamTasksRequest();
             await Assert.ThrowsAsync<TaskCanceledException>(() =>
-                _taskService.GetFilteredTeamTasksAsync(workspaceId, cancellationToken: cts.Token)
+                _taskService.GetFilteredTeamTasksAsync(workspaceId, requestModel, cancellationToken: cts.Token)
             );
         }
 
@@ -562,13 +548,14 @@ namespace ClickUp.Api.Client.Tests.ServiceTests
             var cts = new CancellationTokenSource();
             var expectedToken = cts.Token;
             var expectedResponse = new GetTasksResponse(new List<CuTask> { CreateSampleTask() }, false);
+            var requestModel = new ClickUp.Api.Client.Models.RequestModels.Tasks.GetFilteredTeamTasksRequest();
 
             _mockApiConnection
                 .Setup(x => x.GetAsync<GetTasksResponse>(It.IsAny<string>(), expectedToken))
                 .ReturnsAsync(expectedResponse);
 
             // Act
-            await _taskService.GetFilteredTeamTasksAsync(workspaceId, cancellationToken: expectedToken);
+            await _taskService.GetFilteredTeamTasksAsync(workspaceId, requestModel, cancellationToken: expectedToken);
 
             // Assert
             _mockApiConnection.Verify(x => x.GetAsync<GetTasksResponse>(

--- a/src/ClickUp.Api.Client/Fluent/TasksFluentApi.cs
+++ b/src/ClickUp.Api.Client/Fluent/TasksFluentApi.cs
@@ -66,13 +66,13 @@ public class TasksFluentApi
         return new TemplateFluentCreateTaskRequest(listId, templateId, _tasksService);
     }
 
-    public IAsyncEnumerable<CuTask> GetTasksAsyncEnumerableAsync(string listId, bool? archived = null, bool? includeMarkdownDescription = null, string? orderBy = null, bool? reverse = null, bool? subtasks = null, IEnumerable<string>? statuses = null, bool? includeClosed = null, IEnumerable<string>? assignees = null, IEnumerable<string>? watchers = null, IEnumerable<string>? tags = null, long? dueDateGreaterThan = null, long? dueDateLessThan = null, long? dateCreatedGreaterThan = null, long? dateCreatedLessThan = null, long? dateUpdatedGreaterThan = null, long? dateUpdatedLessThan = null, long? dateDoneGreaterThan = null, long? dateDoneLessThan = null, string? customFields = null, IEnumerable<long>? customItems = null, CancellationToken cancellationToken = default)
+    public IAsyncEnumerable<CuTask> GetTasksAsyncEnumerableAsync(string listId, GetTasksRequest requestModel, CancellationToken cancellationToken = default)
     {
-        return _tasksService.GetTasksAsyncEnumerableAsync(listId, archived, includeMarkdownDescription, orderBy, reverse, subtasks, statuses, includeClosed, assignees, watchers, tags, dueDateGreaterThan, dueDateLessThan, dateCreatedGreaterThan, dateCreatedLessThan, dateUpdatedGreaterThan, dateUpdatedLessThan, dateDoneGreaterThan, dateDoneLessThan, customFields, customItems, cancellationToken);
+        return _tasksService.GetTasksAsyncEnumerableAsync(listId, requestModel, cancellationToken);
     }
 
-    public IAsyncEnumerable<CuTask> GetFilteredTeamTasksAsyncEnumerableAsync(string workspaceId, string? orderBy = null, bool? reverse = null, bool? subtasks = null, IEnumerable<string>? spaceIds = null, IEnumerable<string>? projectIds = null, IEnumerable<string>? listIds = null, IEnumerable<string>? statuses = null, bool? includeClosed = null, IEnumerable<string>? assignees = null, IEnumerable<string>? tags = null, long? dueDateGreaterThan = null, long? dueDateLessThan = null, long? dateCreatedGreaterThan = null, long? dateCreatedLessThan = null, long? dateUpdatedGreaterThan = null, long? dateUpdatedLessThan = null, string? customFields = null, bool? customTaskIds = null, string? teamIdForCustomTaskIds = null, IEnumerable<long>? customItems = null, long? dateDoneGreaterThan = null, long? dateDoneLessThan = null, string? parentTaskId = null, bool? includeMarkdownDescription = null, CancellationToken cancellationToken = default)
+    public IAsyncEnumerable<CuTask> GetFilteredTeamTasksAsyncEnumerableAsync(string workspaceId, GetFilteredTeamTasksRequest requestModel, CancellationToken cancellationToken = default)
     {
-        return _tasksService.GetFilteredTeamTasksAsyncEnumerableAsync(workspaceId, orderBy, reverse, subtasks, spaceIds, projectIds, listIds, statuses, includeClosed, assignees, tags, dueDateGreaterThan, dueDateLessThan, dateCreatedGreaterThan, dateCreatedLessThan, dateUpdatedGreaterThan, dateUpdatedLessThan, customFields, customTaskIds, teamIdForCustomTaskIds, customItems, dateDoneGreaterThan, dateDoneLessThan, parentTaskId, includeMarkdownDescription, cancellationToken);
+        return _tasksService.GetFilteredTeamTasksAsyncEnumerableAsync(workspaceId, requestModel, cancellationToken);
     }
 }

--- a/src/ClickUp.Api.Client/Fluent/TasksFluentGetFilteredTeamRequest.cs
+++ b/src/ClickUp.Api.Client/Fluent/TasksFluentGetFilteredTeamRequest.cs
@@ -48,31 +48,7 @@ public class TasksFluentGetFilteredTeamRequest
     {
         return await _tasksService.GetFilteredTeamTasksAsync(
             _workspaceId,
-            _request.Page,
-            _request.OrderBy,
-            _request.Reverse,
-            _request.Subtasks,
-            _request.SpaceIds,
-            _request.ProjectIds,
-            _request.ListIds,
-            _request.Statuses,
-            _request.IncludeClosed,
-            _request.Assignees,
-            _request.Tags,
-            _request.DueDateGreaterThan,
-            _request.DueDateLessThan,
-            _request.DateCreatedGreaterThan,
-            _request.DateCreatedLessThan,
-            _request.DateUpdatedGreaterThan,
-            _request.DateUpdatedLessThan,
-            _request.CustomFields,
-            _request.CustomTaskIds,
-            _request.TeamIdForCustomTaskIds,
-            _request.CustomItems,
-            _request.DateDoneGreaterThan,
-            _request.DateDoneLessThan,
-            _request.ParentTaskId,
-            _request.IncludeMarkdownDescription
+            _request
         );
     }
 }


### PR DESCRIPTION
- Refactored ITasksService.GetFilteredTeamTasksAsync and its implementation TaskService.GetFilteredTeamTasksAsync to accept a GetFilteredTeamTasksRequest DTO.
- Updated the corresponding fluent API builder TasksFluentGetFilteredTeamRequest to use the new DTO.
- Refactored ITasksService.GetFilteredTeamTasksAsyncEnumerableAsync and its implementation to also use GetFilteredTeamTasksRequest.
- Updated TasksFluentApi.GetFilteredTeamTasksAsyncEnumerableAsync to align with the service changes.
- Refactored ITasksService.GetTasksAsyncEnumerableAsync and its implementation to use GetTasksRequest DTO.
- Updated TasksFluentApi.GetTasksAsyncEnumerableAsync to align.
- Updated all affected unit tests and integration tests to use the new DTOs.
- Corrected XML documentation comments for the refactored methods in ITasksService.