### PR TITLE
Refactor ITasksService to use GetFilteredTeamTasksRequest DTO

### DIFF
--- a/docs/plans/fluentNext.md
+++ b/docs/plans/fluentNext.md
@@ -99,11 +99,11 @@ The following phases outline a roadmap for further developing the Fluent API.
     *   **Value:** Improves the clarity and maintainability of the core service layer. Ensures that the fluent API builders have a consistent and well-structured object to populate, leading to cleaner fluent implementations.
     *   **Tasks:**
         *   - [ ] **General Audit:** Review all `I...Service.cs` methods that return lists or have numerous optional parameters.
-        *   - [ ] **ITasksService Example:**
-            *   - [ ] Refactor `ITasksService.GetFilteredTeamTasksAsync(...)` to accept a `GetFilteredTeamTasksRequest` object.
-            *   - [ ] Update `TasksService.GetFilteredTeamTasksAsync` implementation.
-            *   - [ ] Update `TasksFluentGetFilteredTeamRequest` to build and pass the new request object.
-            *   - [ ] Refactor `ITasksService.GetFilteredTeamTasksAsyncEnumerableAsync(...)` to also accept or internally use the `GetFilteredTeamTasksRequest` object for consistency.
+        *   - [x] **ITasksService Example:**
+            *   - [x] Refactor `ITasksService.GetFilteredTeamTasksAsync(...)` to accept a `GetFilteredTeamTasksRequest` object.
+            *   - [x] Update `TasksService.GetFilteredTeamTasksAsync` implementation.
+            *   - [x] Update `TasksFluentGetFilteredTeamRequest` to build and pass the new request object.
+            *   - [x] Refactor `ITasksService.GetFilteredTeamTasksAsyncEnumerableAsync(...)` to also accept or internally use the `GetFilteredTeamTasksRequest` object for consistency.
         *   - [ ] **Other Services:** Identify and list other service methods requiring similar refactoring based on the audit. For each identified method:
             *   - [ ] Define the new `...Request` DTO.
             *   - [ ] Update the service interface and implementation.

--- a/src/ClickUp.Api.Client.Abstractions/Services/ITasksService.cs
+++ b/src/ClickUp.Api.Client.Abstractions/Services/ITasksService.cs
@@ -129,66 +129,22 @@ namespace ClickUp.Api.Client.Abstractions.Services
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Retrieves Tasks from a Workspace (Team) based on a comprehensive set of filters.
+        /// Retrieves Tasks from a Workspace (Team) based on a comprehensive set of filters defined in the <paramref name="requestModel"/>.
         /// </summary>
         /// <param name="workspaceId">The unique identifier of the Workspace (Team).</param>
-        /// <param name="page">Optional. The page number to fetch for pagination (0-indexed).</param>
-        /// <param name="orderBy">Optional. Field to order Tasks by.</param>
-        /// <param name="reverse">Optional. If true, reverses the sort order.</param>
-        /// <param name="subtasks">Optional. If true, includes subtasks in the results.</param>
-        /// <param name="spaceIds">Optional. An enumerable of Space IDs to filter by.</param>
-        /// <param name="projectIds">Optional. An enumerable of Project IDs (Folders) to filter by.</param>
-        /// <param name="listIds">Optional. An enumerable of List IDs to filter by.</param>
-        /// <param name="statuses">Optional. An enumerable of status names or IDs to filter by.</param>
-        /// <param name="includeClosed">Optional. If true, includes closed Tasks.</param>
-        /// <param name="assignees">Optional. An enumerable of user IDs to filter by assignees.</param>
-        /// <param name="tags">Optional. An enumerable of tag names to filter by.</param>
-        /// <param name="dueDateGreaterThan">Optional. Filters for Tasks with a due date after this Unix timestamp (ms).</param>
-        /// <param name="dueDateLessThan">Optional. Filters for Tasks with a due date before this Unix timestamp (ms).</param>
-        /// <param name="dateCreatedGreaterThan">Optional. Filters for Tasks created after this Unix timestamp (ms).</param>
-        /// <param name="dateCreatedLessThan">Optional. Filters for Tasks created before this Unix timestamp (ms).</param>
-        /// <param name="dateUpdatedGreaterThan">Optional. Filters for Tasks updated after this Unix timestamp (ms).</param>
-        /// <param name="dateUpdatedLessThan">Optional. Filters for Tasks updated before this Unix timestamp (ms).</param>
-        /// <param name="customFields">Optional. A JSON string representing an array of custom field filters.</param>
-        /// <param name="customTaskIds">Optional. If true, indicates that task IDs used in other filters (like projectIds, listIds if they can contain task IDs) are custom task IDs. Also affects how task IDs are exported/returned if applicable.</param>
-        /// <param name="teamIdForCustomTaskIds">Optional. The Workspace ID (team_id), required if <paramref name="customTaskIds"/> is true and custom task IDs are used in filters.</param>
-        /// <param name="customItems">Optional. An enumerable of custom item type IDs (long integers) to filter Tasks by.</param>
-        /// <param name="dateDoneGreaterThan">Optional. Filters for Tasks completed after this Unix timestamp (in milliseconds).</param>
-        /// <param name="dateDoneLessThan">Optional. Filters for Tasks completed before this Unix timestamp (in milliseconds).</param>
-        /// <param name="parentTaskId">Optional. Filters for subtasks of a specific parent Task ID.</param>
-        /// <param name="includeMarkdownDescription">Optional. If set to <c>true</c>, returns Task descriptions in Markdown format. Defaults to <c>false</c>.</param>
+        /// <param name="requestModel">An object containing various filtering, sorting, and pagination options for retrieving Tasks.
+        /// This includes parameters like page number, ordering, inclusion of subtasks, filters for space IDs, project IDs, list IDs,
+        /// statuses, assignees, tags, due dates, creation dates, update dates, completion dates, custom fields, custom task ID settings,
+        /// custom items, parent task ID, and inclusion of Markdown in descriptions.
+        /// </param>
         /// <param name="cancellationToken">A token to observe while waiting for the task to complete, allowing cancellation of the operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains a <see cref="GetTasksResponse"/> object with the list of matching Tasks and pagination details.</returns>
-        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> is null or empty.</exception>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="requestModel"/> is null.</exception>
         /// <exception cref="Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access Tasks in this Workspace.</exception>
         /// <exception cref="Models.Exceptions.ClickUpApiException">Thrown for other API call failures.</exception>
         Task<GetTasksResponse> GetFilteredTeamTasksAsync(
             string workspaceId,
-            int? page = null,
-            string? orderBy = null,
-            bool? reverse = null,
-            bool? subtasks = null,
-            IEnumerable<string>? spaceIds = null,
-            IEnumerable<string>? projectIds = null,
-            IEnumerable<string>? listIds = null,
-            IEnumerable<string>? statuses = null,
-            bool? includeClosed = null,
-            IEnumerable<string>? assignees = null,
-            IEnumerable<string>? tags = null,
-            long? dueDateGreaterThan = null,
-            long? dueDateLessThan = null,
-            long? dateCreatedGreaterThan = null,
-            long? dateCreatedLessThan = null,
-            long? dateUpdatedGreaterThan = null,
-            long? dateUpdatedLessThan = null,
-            string? customFields = null,
-            bool? customTaskIds = null,
-            string? teamIdForCustomTaskIds = null,
-            IEnumerable<long>? customItems = null,
-            long? dateDoneGreaterThan = null,
-            long? dateDoneLessThan = null,
-            string? parentTaskId = null,
-            bool? includeMarkdownDescription = null,
+            GetFilteredTeamTasksRequest requestModel,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -325,64 +281,22 @@ namespace ClickUp.Api.Client.Abstractions.Services
         );
 
         /// <summary>
-        /// Retrieves all Tasks from a Workspace (Team) based on a comprehensive set of filters, automatically handling pagination using <see cref="IAsyncEnumerable{T}"/>.
+        /// Retrieves all Tasks from a Workspace (Team) based on a comprehensive set of filters defined in the <paramref name="requestModel"/>, automatically handling pagination using <see cref="IAsyncEnumerable{T}"/>.
         /// </summary>
         /// <param name="workspaceId">The unique identifier of the Workspace (Team).</param>
-        /// <param name="orderBy">Optional. Field to order Tasks by.</param>
-        /// <param name="reverse">Optional. If true, reverses the sort order.</param>
-        /// <param name="subtasks">Optional. If true, includes subtasks in the results.</param>
-        /// <param name="spaceIds">Optional. An enumerable of Space IDs to filter by.</param>
-        /// <param name="projectIds">Optional. An enumerable of Project IDs (Folders) to filter by.</param>
-        /// <param name="listIds">Optional. An enumerable of List IDs to filter by.</param>
-        /// <param name="statuses">Optional. An enumerable of status names or IDs to filter by.</param>
-        /// <param name="includeClosed">Optional. If true, includes closed Tasks.</param>
-        /// <param name="assignees">Optional. An enumerable of user IDs to filter by assignees.</param>
-        /// <param name="tags">Optional. An enumerable of tag names to filter by.</param>
-        /// <param name="dueDateGreaterThan">Optional. Filters for Tasks with a due date after this Unix timestamp (ms).</param>
-        /// <param name="dueDateLessThan">Optional. Filters for Tasks with a due date before this Unix timestamp (ms).</param>
-        /// <param name="dateCreatedGreaterThan">Optional. Filters for Tasks created after this Unix timestamp (ms).</param>
-        /// <param name="dateCreatedLessThan">Optional. Filters for Tasks created before this Unix timestamp (ms).</param>
-        /// <param name="dateUpdatedGreaterThan">Optional. Filters for Tasks updated after this Unix timestamp (ms).</param>
-        /// <param name="dateUpdatedLessThan">Optional. Filters for Tasks updated before this Unix timestamp (ms).</param>
-        /// <param name="customFields">Optional. A JSON string representing an array of custom field filters.</param>
-        /// <param name="customTaskIds">Optional. If true, indicates that task IDs used in other filters are custom task IDs.</param>
-        /// <param name="teamIdForCustomTaskIds">Optional. The Workspace ID (team_id), required if <paramref name="customTaskIds"/> is true.</param>
-        /// <param name="customItems">Optional. An enumerable of custom item type IDs (long integers) to filter Tasks by.</param>
-        /// <param name="dateDoneGreaterThan">Optional. Filters for Tasks completed after this Unix timestamp (in milliseconds).</param>
-        /// <param name="dateDoneLessThan">Optional. Filters for Tasks completed before this Unix timestamp (in milliseconds).</param>
-        /// <param name="parentTaskId">Optional. Filters for subtasks of a specific parent Task ID.</param>
-        /// <param name="includeMarkdownDescription">Optional. If set to <c>true</c>, returns Task descriptions in Markdown format. Defaults to <c>false</c>.</param>
+        /// <param name="requestModel">An object containing various filtering and sorting options for retrieving Tasks.
+        /// This includes parameters like ordering, inclusion of subtasks, filters for space IDs, project IDs, list IDs,
+        /// statuses, assignees, tags, due dates, creation dates, update dates, completion dates, custom fields, custom task ID settings,
+        /// custom items, parent task ID, and inclusion of Markdown in descriptions. The <see cref="GetFilteredTeamTasksRequest.Page"/> property will be ignored and managed internally for pagination.
+        /// </param>
         /// <param name="cancellationToken">A token to observe while waiting for the task to complete, allowing cancellation of the operation.</param>
         /// <returns>An asynchronous stream of <see cref="CuTask"/> objects from the specified Workspace matching the filters.</returns>
-        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> is null or empty.</exception>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="workspaceId"/> or <paramref name="requestModel"/> is null.</exception>
         /// <exception cref="Models.Exceptions.ClickUpApiAuthenticationException">Thrown if the user is not authorized to access Tasks in this Workspace.</exception>
         /// <exception cref="Models.Exceptions.ClickUpApiException">Thrown if an API call fails during the pagination process.</exception>
         IAsyncEnumerable<CuTask> GetFilteredTeamTasksAsyncEnumerableAsync(
             string workspaceId,
-            string? orderBy = null,
-            bool? reverse = null,
-            bool? subtasks = null,
-            IEnumerable<string>? spaceIds = null,
-            IEnumerable<string>? projectIds = null,
-            IEnumerable<string>? listIds = null,
-            IEnumerable<string>? statuses = null,
-            bool? includeClosed = null,
-            IEnumerable<string>? assignees = null,
-            IEnumerable<string>? tags = null,
-            long? dueDateGreaterThan = null,
-            long? dueDateLessThan = null,
-            long? dateCreatedGreaterThan = null,
-            long? dateCreatedLessThan = null,
-            long? dateUpdatedGreaterThan = null,
-            long? dateUpdatedLessThan = null,
-            string? customFields = null,
-            bool? customTaskIds = null,
-            string? teamIdForCustomTaskIds = null,
-            IEnumerable<long>? customItems = null,
-            long? dateDoneGreaterThan = null,
-            long? dateDoneLessThan = null,
-            string? parentTaskId = null,
-            bool? includeMarkdownDescription = null,
+            GetFilteredTeamTasksRequest requestModel,
             CancellationToken cancellationToken = default
         );
     }

--- a/src/ClickUp.Api.Client.IntegrationTests/Integration/TaskServiceIntegrationTests.cs
+++ b/src/ClickUp.Api.Client.IntegrationTests/Integration/TaskServiceIntegrationTests.cs
@@ -572,8 +572,8 @@ namespace ClickUp.Api.Client.IntegrationTests.Integration
             if(CurrentTestMode == TestMode.Playback) { Assert.Equal(taskInList1Id, taskInList1.Id); Assert.Equal(taskInOtherListId, taskInOtherList.Id); }
 
 
-            var response = await _taskService.GetFilteredTeamTasksAsync(workspaceId: _testWorkspaceId, listIds: new List<string> { _testListId });
-            Assert.NotNull(response?.Tasks);
+            var requestModel = new GetFilteredTeamTasksRequest { ListIds = new List<string> { _testListId } };
+            var response = await _taskService.GetFilteredTeamTasksAsync(workspaceId: _testWorkspaceId, requestModel: requestModel); Assert.NotNull(response?.Tasks);
             Assert.Contains(response.Tasks, t => t.Id == taskInList1.Id);
             Assert.DoesNotContain(response.Tasks, t => t.Id == taskInOtherList.Id);
         }
@@ -631,7 +631,11 @@ namespace ClickUp.Api.Client.IntegrationTests.Integration
 
 
             var retrievedTasks = new List<CuTask>();
-            await foreach (var task in _taskService.GetFilteredTeamTasksAsyncEnumerableAsync(_testWorkspaceId, listIds: new List<string> { _testListId })) { retrievedTasks.Add(task); }
+            var requestModel = new GetFilteredTeamTasksRequest { ListIds = new List<string> { _testListId } };
+            await foreach (var task in _taskService.GetFilteredTeamTasksAsyncEnumerableAsync(_testWorkspaceId, requestModel))
+            {
+                retrievedTasks.Add(task);
+            }
             Assert.Equal(tasksToCreate, retrievedTasks.Count);
             if(CurrentTestMode == TestMode.Playback) { Assert.Contains(retrievedTasks, rt => rt.Id == "playback_team_pag_task_1"); Assert.Contains(retrievedTasks, rt => rt.Id == "playback_team_pag_task_2"); Assert.DoesNotContain(retrievedTasks, rt => rt.Id == "playback_task_in_other_list_team_pag");}
         }

--- a/src/ClickUp.Api.Client.Tests/ServiceTests/Fluent/FluentTasksApiTests.cs
+++ b/src/ClickUp.Api.Client.Tests/ServiceTests/Fluent/FluentTasksApiTests.cs
@@ -8,6 +8,7 @@ using Moq;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using ClickUp.Api.Client.Models.RequestModels.Tasks;
 using Xunit;
 
 namespace ClickUp.Api.Client.Tests.ServiceTests.Fluent;
@@ -69,33 +70,9 @@ public class FluentTasksApiTests
 
         var mockTasksService = new Mock<ITasksService>();
         mockTasksService.Setup(x => x.GetFilteredTeamTasksAsync(
-            It.IsAny<string>(),
-            It.IsAny<int?>(),
-            It.IsAny<string?>(),
-            It.IsAny<bool?>(),
-            It.IsAny<bool?>(),
-            It.IsAny<IEnumerable<string>?>(),
-            It.IsAny<IEnumerable<string>?>(),
-            It.IsAny<IEnumerable<string>?>(),
-            It.IsAny<IEnumerable<string>?>(),
-            It.IsAny<bool?>(),
-            It.IsAny<IEnumerable<string>?>(),
-            It.IsAny<IEnumerable<string>?>(),
-            It.IsAny<long?>(),
-            It.IsAny<long?>(),
-            It.IsAny<long?>(),
-            It.IsAny<long?>(),
-            It.IsAny<long?>(),
-            It.IsAny<long?>(),
-            It.IsAny<string?>(),
-            It.IsAny<bool?>(),
-            It.IsAny<string?>(),
-            It.IsAny<IEnumerable<long>?>(),
-            It.IsAny<long?>(),
-            It.IsAny<long?>(),
-            It.IsAny<string?>(),
-            It.IsAny<bool?>(),
-            It.IsAny<CancellationToken>()))
+                It.IsAny<string>(),
+                It.IsAny<GetFilteredTeamTasksRequest>(),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedResponse);
 
         var fluentTasksApi = new TasksFluentApi(mockTasksService.Object);
@@ -110,31 +87,9 @@ public class FluentTasksApiTests
         Assert.Equal(expectedResponse, result);
         mockTasksService.Verify(x => x.GetFilteredTeamTasksAsync(
             workspaceId,
-            null, // page
-            null, // orderBy
-            null, // reverse
-            true, // subtasks
-            null, // spaceIds
-            null, // projectIds
-            null, // listIds
-            null, // statuses
-            false, // includeClosed
-            null, // assignees
-            null, // tags
-            null, // dueDateGreaterThan
-            null, // dueDateLessThan
-            null, // dateCreatedGreaterThan
-            null, // dateCreatedLessThan
-            null, // dateUpdatedGreaterThan
-            null, // dateUpdatedLessThan
-            null, // customFields
-            null, // customTaskIds
-            null, // teamIdForCustomTaskIds
-            null, // customItems
-            null, // dateDoneGreaterThan
-            null, // dateDoneLessThan
-            null, // parentTaskId
-            null, // includeMarkdownDescription
+            It.Is<GetFilteredTeamTasksRequest>(req =>
+                req.Subtasks == true &&
+                req.IncludeClosed == false),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/src/ClickUp.Api.Client/Fluent/TasksFluentApi.cs
+++ b/src/ClickUp.Api.Client/Fluent/TasksFluentApi.cs
@@ -71,8 +71,8 @@ public class TasksFluentApi
         return _tasksService.GetTasksAsyncEnumerableAsync(listId, archived, includeMarkdownDescription, orderBy, reverse, subtasks, statuses, includeClosed, assignees, watchers, tags, dueDateGreaterThan, dueDateLessThan, dateCreatedGreaterThan, dateCreatedLessThan, dateUpdatedGreaterThan, dateUpdatedLessThan, dateDoneGreaterThan, dateDoneLessThan, customFields, customItems, cancellationToken);
     }
 
-    public IAsyncEnumerable<CuTask> GetFilteredTeamTasksAsyncEnumerableAsync(string workspaceId, string? orderBy = null, bool? reverse = null, bool? subtasks = null, IEnumerable<string>? spaceIds = null, IEnumerable<string>? projectIds = null, IEnumerable<string>? listIds = null, IEnumerable<string>? statuses = null, bool? includeClosed = null, IEnumerable<string>? assignees = null, IEnumerable<string>? tags = null, long? dueDateGreaterThan = null, long? dueDateLessThan = null, long? dateCreatedGreaterThan = null, long? dateCreatedLessThan = null, long? dateUpdatedGreaterThan = null, long? dateUpdatedLessThan = null, string? customFields = null, bool? customTaskIds = null, string? teamIdForCustomTaskIds = null, IEnumerable<long>? customItems = null, long? dateDoneGreaterThan = null, long? dateDoneLessThan = null, string? parentTaskId = null, bool? includeMarkdownDescription = null, CancellationToken cancellationToken = default)
+    public IAsyncEnumerable<CuTask> GetFilteredTeamTasksAsyncEnumerableAsync(string workspaceId, GetFilteredTeamTasksRequest requestModel, CancellationToken cancellationToken = default)
     {
-        return _tasksService.GetFilteredTeamTasksAsyncEnumerableAsync(workspaceId, orderBy, reverse, subtasks, spaceIds, projectIds, listIds, statuses, includeClosed, assignees, tags, dueDateGreaterThan, dueDateLessThan, dateCreatedGreaterThan, dateCreatedLessThan, dateUpdatedGreaterThan, dateUpdatedLessThan, customFields, customTaskIds, teamIdForCustomTaskIds, customItems, dateDoneGreaterThan, dateDoneLessThan, parentTaskId, includeMarkdownDescription, cancellationToken);
+        return _tasksService.GetFilteredTeamTasksAsyncEnumerableAsync(workspaceId, requestModel, cancellationToken);
     }
 }

--- a/src/ClickUp.Api.Client/Fluent/TasksFluentGetFilteredTeamRequest.cs
+++ b/src/ClickUp.Api.Client/Fluent/TasksFluentGetFilteredTeamRequest.cs
@@ -44,35 +44,12 @@ public class TasksFluentGetFilteredTeamRequest
     public TasksFluentGetFilteredTeamRequest WithParentTaskId(string parentTaskId) { _request.ParentTaskId = parentTaskId; return this; }
     public TasksFluentGetFilteredTeamRequest WithIncludeMarkdownDescription(bool includeMarkdownDescription) { _request.IncludeMarkdownDescription = includeMarkdownDescription; return this; }
 
-    public async Task<GetTasksResponse> GetAsync()
+    public async Task<GetTasksResponse> GetAsync(System.Threading.CancellationToken cancellationToken = default)
     {
         return await _tasksService.GetFilteredTeamTasksAsync(
             _workspaceId,
-            _request.Page,
-            _request.OrderBy,
-            _request.Reverse,
-            _request.Subtasks,
-            _request.SpaceIds,
-            _request.ProjectIds,
-            _request.ListIds,
-            _request.Statuses,
-            _request.IncludeClosed,
-            _request.Assignees,
-            _request.Tags,
-            _request.DueDateGreaterThan,
-            _request.DueDateLessThan,
-            _request.DateCreatedGreaterThan,
-            _request.DateCreatedLessThan,
-            _request.DateUpdatedGreaterThan,
-            _request.DateUpdatedLessThan,
-            _request.CustomFields,
-            _request.CustomTaskIds,
-            _request.TeamIdForCustomTaskIds,
-            _request.CustomItems,
-            _request.DateDoneGreaterThan,
-            _request.DateDoneLessThan,
-            _request.ParentTaskId,
-            _request.IncludeMarkdownDescription
+            _request,
+            cancellationToken
         );
     }
 }

--- a/src/ClickUp.Api.Client/Services/TaskService.cs
+++ b/src/ClickUp.Api.Client/Services/TaskService.cs
@@ -439,73 +439,53 @@ namespace ClickUp.Api.Client.Services
         /// <inheritdoc />
         public async Task<GetTasksResponse> GetFilteredTeamTasksAsync(
             string workspaceId,
-            int? page = null,
-            string? orderBy = null,
-            bool? reverse = null,
-            bool? subtasks = null,
-            IEnumerable<string>? spaceIds = null,
-            IEnumerable<string>? projectIds = null,
-            IEnumerable<string>? listIds = null,
-            IEnumerable<string>? statuses = null,
-            bool? includeClosed = null,
-            IEnumerable<string>? assignees = null,
-            IEnumerable<string>? tags = null,
-            long? dueDateGreaterThan = null,
-            long? dueDateLessThan = null,
-            long? dateCreatedGreaterThan = null,
-            long? dateCreatedLessThan = null,
-            long? dateUpdatedGreaterThan = null,
-            long? dateUpdatedLessThan = null,
-            string? customFields = null,
-            bool? customTaskIds = null, // Name in interface
-            string? teamIdForCustomTaskIds = null, // Name in interface
-            IEnumerable<long>? customItems = null,
-            long? dateDoneGreaterThan = null,
-            long? dateDoneLessThan = null,
-            string? parentTaskId = null,
-            bool? includeMarkdownDescription = null,
+            GetFilteredTeamTasksRequest requestModel,
             CancellationToken cancellationToken = default)
         {
-            _logger.LogInformation("Getting filtered team tasks for workspace ID: {WorkspaceId}, Page: {Page}", workspaceId, page);
+            _logger.LogInformation("Getting filtered team tasks for workspace ID: {WorkspaceId}, Page: {Page}", workspaceId, requestModel.Page);
             if (string.IsNullOrWhiteSpace(workspaceId))
             {
                 throw new ArgumentNullException(nameof(workspaceId));
+            }
+            if (requestModel == null)
+            {
+                throw new ArgumentNullException(nameof(requestModel));
             }
 
             var endpoint = $"team/{workspaceId}/task";
             var queryParams = new Dictionary<string, string?>();
 
-            if (page.HasValue) queryParams["page"] = page.Value.ToString();
-            if (!string.IsNullOrEmpty(orderBy)) queryParams["order_by"] = orderBy;
-            if (reverse.HasValue) queryParams["reverse"] = reverse.Value.ToString().ToLower();
-            if (subtasks.HasValue) queryParams["subtasks"] = subtasks.Value.ToString().ToLower();
-            if (includeClosed.HasValue) queryParams["include_closed"] = includeClosed.Value.ToString().ToLower();
+            if (requestModel.Page.HasValue) queryParams["page"] = requestModel.Page.Value.ToString();
+            if (!string.IsNullOrEmpty(requestModel.OrderBy)) queryParams["order_by"] = requestModel.OrderBy;
+            if (requestModel.Reverse.HasValue) queryParams["reverse"] = requestModel.Reverse.Value.ToString().ToLower();
+            if (requestModel.Subtasks.HasValue) queryParams["subtasks"] = requestModel.Subtasks.Value.ToString().ToLower();
+            if (requestModel.IncludeClosed.HasValue) queryParams["include_closed"] = requestModel.IncludeClosed.Value.ToString().ToLower();
 
-            if (dueDateGreaterThan.HasValue) queryParams["due_date_gt"] = dueDateGreaterThan.Value.ToString();
-            if (dueDateLessThan.HasValue) queryParams["due_date_lt"] = dueDateLessThan.Value.ToString();
-            if (dateCreatedGreaterThan.HasValue) queryParams["date_created_gt"] = dateCreatedGreaterThan.Value.ToString();
-            if (dateCreatedLessThan.HasValue) queryParams["date_created_lt"] = dateCreatedLessThan.Value.ToString();
-            if (dateUpdatedGreaterThan.HasValue) queryParams["date_updated_gt"] = dateUpdatedGreaterThan.Value.ToString();
-            if (dateUpdatedLessThan.HasValue) queryParams["date_updated_lt"] = dateUpdatedLessThan.Value.ToString();
-            if (dateDoneGreaterThan.HasValue) queryParams["date_done_gt"] = dateDoneGreaterThan.Value.ToString();
-            if (dateDoneLessThan.HasValue) queryParams["date_done_lt"] = dateDoneLessThan.Value.ToString();
-            if (!string.IsNullOrEmpty(parentTaskId)) queryParams["parent"] = parentTaskId;
-            if (includeMarkdownDescription.HasValue) queryParams["include_markdown_description"] = includeMarkdownDescription.Value.ToString().ToLower();
+            if (requestModel.DueDateGreaterThan.HasValue) queryParams["due_date_gt"] = requestModel.DueDateGreaterThan.Value.ToString();
+            if (requestModel.DueDateLessThan.HasValue) queryParams["due_date_lt"] = requestModel.DueDateLessThan.Value.ToString();
+            if (requestModel.DateCreatedGreaterThan.HasValue) queryParams["date_created_gt"] = requestModel.DateCreatedGreaterThan.Value.ToString();
+            if (requestModel.DateCreatedLessThan.HasValue) queryParams["date_created_lt"] = requestModel.DateCreatedLessThan.Value.ToString();
+            if (requestModel.DateUpdatedGreaterThan.HasValue) queryParams["date_updated_gt"] = requestModel.DateUpdatedGreaterThan.Value.ToString();
+            if (requestModel.DateUpdatedLessThan.HasValue) queryParams["date_updated_lt"] = requestModel.DateUpdatedLessThan.Value.ToString();
+            if (requestModel.DateDoneGreaterThan.HasValue) queryParams["date_done_gt"] = requestModel.DateDoneGreaterThan.Value.ToString();
+            if (requestModel.DateDoneLessThan.HasValue) queryParams["date_done_lt"] = requestModel.DateDoneLessThan.Value.ToString();
+            if (!string.IsNullOrEmpty(requestModel.ParentTaskId)) queryParams["parent"] = requestModel.ParentTaskId;
+            if (requestModel.IncludeMarkdownDescription.HasValue) queryParams["include_markdown_description"] = requestModel.IncludeMarkdownDescription.Value.ToString().ToLower();
 
-            if (!string.IsNullOrEmpty(customFields)) queryParams["custom_fields"] = customFields;
-            if (customTaskIds.HasValue) queryParams["custom_task_ids"] = customTaskIds.Value.ToString().ToLower();
-            if (!string.IsNullOrEmpty(teamIdForCustomTaskIds)) queryParams["team_id"] = teamIdForCustomTaskIds;
+            if (!string.IsNullOrEmpty(requestModel.CustomFields)) queryParams["custom_fields"] = requestModel.CustomFields;
+            if (requestModel.CustomTaskIds.HasValue) queryParams["custom_task_ids"] = requestModel.CustomTaskIds.Value.ToString().ToLower();
+            if (!string.IsNullOrEmpty(requestModel.TeamIdForCustomTaskIds)) queryParams["team_id"] = requestModel.TeamIdForCustomTaskIds;
 
             var queryString = BuildQueryString(queryParams);
 
             var arrayParams = new List<string>();
-            if (spaceIds != null && spaceIds.Any()) arrayParams.Add(BuildQueryStringFromArray("space_ids", spaceIds));
-            if (projectIds != null && projectIds.Any()) arrayParams.Add(BuildQueryStringFromArray("project_ids", projectIds));
-            if (listIds != null && listIds.Any()) arrayParams.Add(BuildQueryStringFromArray("list_ids", listIds));
-            if (statuses != null && statuses.Any()) arrayParams.Add(BuildQueryStringFromArray("statuses", statuses));
-            if (assignees != null && assignees.Any()) arrayParams.Add(BuildQueryStringFromArray("assignees", assignees));
-            if (tags != null && tags.Any()) arrayParams.Add(BuildQueryStringFromArray("tags", tags));
-            if (customItems != null && customItems.Any()) arrayParams.Add(BuildQueryStringFromArray("custom_items", customItems.Select(ci => ci.ToString())));
+            if (requestModel.SpaceIds != null && requestModel.SpaceIds.Any()) arrayParams.Add(BuildQueryStringFromArray("space_ids", requestModel.SpaceIds));
+            if (requestModel.ProjectIds != null && requestModel.ProjectIds.Any()) arrayParams.Add(BuildQueryStringFromArray("project_ids", requestModel.ProjectIds));
+            if (requestModel.ListIds != null && requestModel.ListIds.Any()) arrayParams.Add(BuildQueryStringFromArray("list_ids", requestModel.ListIds));
+            if (requestModel.Statuses != null && requestModel.Statuses.Any()) arrayParams.Add(BuildQueryStringFromArray("statuses", requestModel.Statuses));
+            if (requestModel.Assignees != null && requestModel.Assignees.Any()) arrayParams.Add(BuildQueryStringFromArray("assignees", requestModel.Assignees));
+            if (requestModel.Tags != null && requestModel.Tags.Any()) arrayParams.Add(BuildQueryStringFromArray("tags", requestModel.Tags));
+            if (requestModel.CustomItems != null && requestModel.CustomItems.Any()) arrayParams.Add(BuildQueryStringFromArray("custom_items", requestModel.CustomItems.Select(ci => ci.ToString())));
 
             if (arrayParams.Any(p => !string.IsNullOrEmpty(p)))
             {
@@ -525,31 +505,7 @@ namespace ClickUp.Api.Client.Services
         /// <inheritdoc />
         public async IAsyncEnumerable<CuTask> GetFilteredTeamTasksAsyncEnumerableAsync(
             string workspaceId,
-            string? orderBy = null,
-            bool? reverse = null,
-            bool? subtasks = null,
-            IEnumerable<string>? spaceIds = null,
-            IEnumerable<string>? projectIds = null,
-            IEnumerable<string>? listIds = null,
-            IEnumerable<string>? statuses = null,
-            bool? includeClosed = null,
-            IEnumerable<string>? assignees = null,
-            IEnumerable<string>? tags = null,
-            long? dueDateGreaterThan = null,
-            long? dueDateLessThan = null,
-            long? dateCreatedGreaterThan = null,
-            long? dateCreatedLessThan = null,
-            long? dateUpdatedGreaterThan = null,
-            long? dateUpdatedLessThan = null,
-            // Removed duplicate dateDoneGreaterThan and dateDoneLessThan
-            string? customFields = null,
-            bool? queryCustomTaskIds = null,
-            string? teamIdForQueryCustomTaskIds = null,
-            IEnumerable<long>? customItems = null,
-            long? dateDoneGreaterThan = null, // Kept one set of these
-            long? dateDoneLessThan = null,
-            string? parentTaskId = null,
-            bool? includeMarkdownDescription = null,
+            GetFilteredTeamTasksRequest requestModel,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             _logger.LogInformation("Getting filtered team tasks as an async enumerable for workspace ID: {WorkspaceId}", workspaceId);
@@ -557,6 +513,40 @@ namespace ClickUp.Api.Client.Services
             {
                 throw new ArgumentNullException(nameof(workspaceId));
             }
+            if (requestModel == null)
+            {
+                throw new ArgumentNullException(nameof(requestModel));
+            }
+
+            // Clone the request model to modify the Page property without affecting the original
+            var pagedRequestModel = new GetFilteredTeamTasksRequest
+            {
+                OrderBy = requestModel.OrderBy,
+                Reverse = requestModel.Reverse,
+                Subtasks = requestModel.Subtasks,
+                SpaceIds = requestModel.SpaceIds,
+                ProjectIds = requestModel.ProjectIds,
+                ListIds = requestModel.ListIds,
+                Statuses = requestModel.Statuses,
+                IncludeClosed = requestModel.IncludeClosed,
+                Assignees = requestModel.Assignees,
+                Tags = requestModel.Tags,
+                DueDateGreaterThan = requestModel.DueDateGreaterThan,
+                DueDateLessThan = requestModel.DueDateLessThan,
+                DateCreatedGreaterThan = requestModel.DateCreatedGreaterThan,
+                DateCreatedLessThan = requestModel.DateCreatedLessThan,
+                DateUpdatedGreaterThan = requestModel.DateUpdatedGreaterThan,
+                DateUpdatedLessThan = requestModel.DateUpdatedLessThan,
+                CustomFields = requestModel.CustomFields,
+                CustomTaskIds = requestModel.CustomTaskIds,
+                TeamIdForCustomTaskIds = requestModel.TeamIdForCustomTaskIds,
+                CustomItems = requestModel.CustomItems,
+                DateDoneGreaterThan = requestModel.DateDoneGreaterThan,
+                DateDoneLessThan = requestModel.DateDoneLessThan,
+                ParentTaskId = requestModel.ParentTaskId,
+                IncludeMarkdownDescription = requestModel.IncludeMarkdownDescription
+                // Page will be set in the loop
+            };
 
             int currentPage = 0;
             bool lastPage;
@@ -566,33 +556,11 @@ namespace ClickUp.Api.Client.Services
                 cancellationToken.ThrowIfCancellationRequested(); // Check before API call
 
                 _logger.LogDebug("Fetching page {PageNumber} for filtered team tasks in workspace ID {WorkspaceId} via async enumerable.", currentPage, workspaceId);
+                pagedRequestModel.Page = currentPage; // Set the current page for this request
+
                 var response = await GetFilteredTeamTasksAsync(
                     workspaceId: workspaceId,
-                    page: currentPage,
-                    orderBy: orderBy,
-                    reverse: reverse,
-                    subtasks: subtasks,
-                    spaceIds: spaceIds,
-                    projectIds: projectIds,
-                    listIds: listIds,
-                    statuses: statuses,
-                    includeClosed: includeClosed,
-                    assignees: assignees,
-                    tags: tags,
-                    dueDateGreaterThan: dueDateGreaterThan,
-                    dueDateLessThan: dueDateLessThan,
-                    dateCreatedGreaterThan: dateCreatedGreaterThan,
-                    dateCreatedLessThan: dateCreatedLessThan,
-                    dateUpdatedGreaterThan: dateUpdatedGreaterThan,
-                    dateUpdatedLessThan: dateUpdatedLessThan,
-                    customFields: customFields,
-                    customTaskIds: queryCustomTaskIds, // Ensure mapping to the correct parameter name
-                    teamIdForCustomTaskIds: teamIdForQueryCustomTaskIds, // Ensure mapping
-                    customItems: customItems,
-                    dateDoneGreaterThan: dateDoneGreaterThan,
-                    dateDoneLessThan: dateDoneLessThan,
-                    parentTaskId: parentTaskId,
-                    includeMarkdownDescription: includeMarkdownDescription,
+                    requestModel: pagedRequestModel, // Pass the modified request model
                     cancellationToken: cancellationToken
                 ).ConfigureAwait(false);
 


### PR DESCRIPTION
This commit refactors the ITasksService.GetFilteredTeamTasksAsync and ITasksService.GetFilteredTeamTasksAsyncEnumerableAsync methods to use a new GetFilteredTeamTasksRequest DTO.

Changes include:
- Created GetFilteredTeamTasksRequest.cs to encapsulate filter parameters.
- Updated ITasksService.cs method signatures and XML documentation.
- Updated TaskService.cs implementations to use the new DTO.
- Updated TasksFluentGetFilteredTeamRequest.cs to build and pass the DTO.
- Updated docs/plans/fluentNext.md to reflect completion of these tasks.

This change improves the maintainability and clarity of the service layer by reducing the number of parameters in method signatures and prepares for further fluent API enhancements.